### PR TITLE
Reduced head movement

### DIFF
--- a/bitbots_head_behavior/config/head_config.yaml
+++ b/bitbots_head_behavior/config/head_config.yaml
@@ -18,6 +18,11 @@ behavior:
       - [30, -7]
       - [-30, -7]
 
+    # These values describe the minimal required delta between current joint states and target joint states
+    # to reduce unnecessary movement due to noise in the detection of the BallRelative.
+    ball_tracking_min_pan_delta: 4
+    ball_tracking_min_tilt_delta: 4
+
     # Positions for static head modes
     look_down_position: [0, -65]
     look_forward_position: [0, -7]

--- a/bitbots_head_behavior/config/head_config.yaml
+++ b/bitbots_head_behavior/config/head_config.yaml
@@ -18,7 +18,7 @@ behavior:
       - [30, -7]
       - [-30, -7]
 
-    # These values describe the minimal required delta between current joint states and target joint states
+    # These values describe the minimal required delta between current joint states and target joint states in degrees
     # to reduce unnecessary movement due to noise in the detection of the BallRelative.
     ball_tracking_min_pan_delta: 4
     ball_tracking_min_tilt_delta: 4

--- a/bitbots_head_behavior/config/head_config.yaml
+++ b/bitbots_head_behavior/config/head_config.yaml
@@ -20,8 +20,8 @@ behavior:
 
     # These values describe the minimal required delta between current joint states and target joint states in degrees
     # to reduce unnecessary movement due to noise in the detection of the BallRelative.
-    ball_tracking_min_pan_delta: 4
-    ball_tracking_min_tilt_delta: 4
+    ball_tracking_min_pan_delta: 8
+    ball_tracking_min_tilt_delta: 5
 
     # Positions for static head modes
     look_down_position: [0, -65]

--- a/bitbots_head_behavior/src/bitbots_head_behavior/actions/look_at.py
+++ b/bitbots_head_behavior/src/bitbots_head_behavior/actions/look_at.py
@@ -38,13 +38,16 @@ class AbstractLookAt(AbstractActionElement):
         states = response.solution.joint_state
         return states.position[states.name.index('HeadPan')], states.position[states.name.index('HeadTilt')]
 
-    def _look_at(self, point):
+    def _look_at(self, point, min_pan_delta=0, min_tilt_delta=0):
         """
         Look at a point which is relative to the robot.
 
-        The points header.frame_id determines the transforms reference frame of this point
+        The points header.frame_id determines the transforms reference frame of this point.
+        The min_pan_delta and min_tilt_delta define minimal required movements to reduce unnecessary head movements.
 
         :type point: PointStamped
+        :type min_pan_delta: float
+        :type min_tilt_delta: float
         """
         # transform the points reference frame to be the head
         try:
@@ -60,7 +63,9 @@ class AbstractLookAt(AbstractActionElement):
             return
 
         head_pan, head_tilt = self.get_motor_goals_from_point(point.point)
-        self.blackboard.head_capsule.send_motor_goals(head_pan, head_tilt)
+        current_head_pan, current_head_tilt = self.blackboard.head_capsule.get_head_position()
+        if abs(current_head_pan - head_pan) >= min_pan_delta or abs(current_head_tilt - head_tilt) >= min_tilt_delta:
+            self.blackboard.head_capsule.send_motor_goals(head_pan, head_tilt)
 
 
 class LookDirection(AbstractLookAt):

--- a/bitbots_head_behavior/src/bitbots_head_behavior/actions/look_at.py
+++ b/bitbots_head_behavior/src/bitbots_head_behavior/actions/look_at.py
@@ -43,7 +43,7 @@ class AbstractLookAt(AbstractActionElement):
         Look at a point which is relative to the robot.
 
         The points header.frame_id determines the transforms reference frame of this point.
-        The min_pan_delta and min_tilt_delta define minimal required movements to reduce unnecessary head movements.
+        The min_pan_delta and min_tilt_delta define minimal required movements in degrees to reduce unnecessary head movements.
 
         :type point: PointStamped
         :type min_pan_delta: float
@@ -64,7 +64,8 @@ class AbstractLookAt(AbstractActionElement):
 
         head_pan, head_tilt = self.get_motor_goals_from_point(point.point)
         current_head_pan, current_head_tilt = self.blackboard.head_capsule.get_head_position()
-        if abs(current_head_pan - head_pan) >= min_pan_delta or abs(current_head_tilt - head_tilt) >= min_tilt_delta:
+        if abs(current_head_pan - head_pan) >= math.radians(min_pan_delta) or \
+                abs(current_head_tilt - head_tilt) >= math.radians(min_tilt_delta):
             self.blackboard.head_capsule.send_motor_goals(head_pan, head_tilt)
 
 

--- a/bitbots_head_behavior/src/bitbots_head_behavior/actions/track_ball.py
+++ b/bitbots_head_behavior/src/bitbots_head_behavior/actions/track_ball.py
@@ -12,6 +12,8 @@ class TrackBall(AbstractLookAt):
 
     def __init__(self, dsd, blackboard, parameters=None):
         super(TrackBall, self).__init__(dsd, blackboard, parameters)
+        self.ball_tracking_min_pan_delta = self.blackboard.config['ball_tracking_min_pan_delta']
+        self.ball_tracking_min_tilt_delta = self.blackboard.config['ball_tracking_min_tilt_delta']
 
     def perform(self, reevaluate=False):
         """
@@ -23,5 +25,5 @@ class TrackBall(AbstractLookAt):
         # Get last ball position
         point = self.blackboard.world_model.get_ball_stamped()
 
-        # Call internal look-at to turn head to this point
-        self._look_at(point)
+        # Call internal look-at to turn head to this point (when necessary)
+        self._look_at(point, self.ball_tracking_min_pan_delta, self.ball_tracking_min_tilt_delta)


### PR DESCRIPTION
This commit addresses #2. It sets deltas for the head movement to prevent unnecessary small movements of the head to track the ball. 
This is NOT tested. The parameters (currently set to 4) are NOT evaluated and just guessed.