### PR TITLE
initial implementation of BallDangerous

### DIFF
--- a/bitbots_blackboard/src/bitbots_blackboard/blackboard.py
+++ b/bitbots_blackboard/src/bitbots_blackboard/blackboard.py
@@ -15,6 +15,7 @@ class BodyBlackboard:
         # it is just that I don't know where this will be placed later
         self.field_width = 6
         self.field_length = 9
+        self.goal_width = 2.6
 
         self.config = rospy.get_param("behavior/body")
         self.blackboard = BlackboardCapsule()

--- a/bitbots_body_behavior/config/body_behavior.yaml
+++ b/bitbots_body_behavior/config/body_behavior.yaml
@@ -33,3 +33,8 @@ behavior:
     # When the ball is closer than `max_kick_distance` meters
     # it is close enough to be kicked
     max_kick_distance: 0.3
+
+    # defines the radius around the goal (in form of a box)
+    # in this area, the goalie will react to the ball.
+    # the radius is the margin around the goal to both y and the positive x directions
+    ball_dangerous_goal_radius: 1

--- a/bitbots_body_behavior/src/bitbots_body_behavior/decisions/ball_dangerous.py
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/decisions/ball_dangerous.py
@@ -4,7 +4,7 @@ from dynamic_stack_decider.abstract_decision_element import AbstractDecisionElem
 class BallDangerous(AbstractDecisionElement):
     def __init__(self, blackboard, dsd, parameters=None):
         super(BallDangerous, self).__init__(blackboard, dsd, parameters)
-        self.ball_dangerous_goal_radius = self.blackboard.config['ball_dangerous_goal_radius']
+        self.goal_radius = self.blackboard.config['ball_dangerous_goal_radius']
 
     def perform(self, reevaluate=False):
         if self._in_dangerous_area(self.blackboard.world_model.get_ball_position_xy()):
@@ -17,16 +17,13 @@ class BallDangerous(AbstractDecisionElement):
         """
 
         # close enough on the x axis
-        if position[0] > -(self.blackboard.field_length / 2) + self.ball_dangerous_goal_radius:
+        if position[0] > -(self.blackboard.field_length / 2) + self.goal_radius:
             return False
 
-        if (-self.blackboard.goal_width / 2) - self.ball_dangerous_goal_radius <= \
-                position[1] <= \
-                (self.blackboard.goal_width / 2) + self.ball_dangerous_goal_radius:
+        # in the y-area in front of the goal (respecting the radius
+        if abs(position[1]) <= (self.blackboard.goal_width / 2 + self.goal_radius):
             return True
         return False
-
-
 
     def get_reevaluate(self):
         return True

--- a/bitbots_body_behavior/src/bitbots_body_behavior/decisions/ball_dangerous.py
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/decisions/ball_dangerous.py
@@ -2,4 +2,32 @@ from dynamic_stack_decider.abstract_decision_element import AbstractDecisionElem
 
 
 class BallDangerous(AbstractDecisionElement):
-    pass
+    def __init__(self, blackboard, dsd, parameters=None):
+        super(BallDangerous, self).__init__(blackboard, dsd, parameters)
+        self.ball_dangerous_goal_radius = self.blackboard.config['ball_dangerous_goal_radius']
+
+    def perform(self, reevaluate=False):
+        if self._in_dangerous_area(self.blackboard.world_model.get_ball_position_xy()):
+            return 'YES'
+        return 'NO'
+
+    def _in_dangerous_area(self, position):
+        """"
+        returns whether the position is in the dangerous area (close to the goal)
+        """
+
+        # close enough on the x axis
+        if position[0] > -(self.blackboard.field_length / 2) + self.ball_dangerous_goal_radius:
+            return False
+
+        if (-self.blackboard.goal_width / 2) - self.ball_dangerous_goal_radius <= \
+                position[1] <= \
+                (self.blackboard.goal_width / 2) + self.ball_dangerous_goal_radius:
+            return True
+        return False
+
+
+
+    def get_reevaluate(self):
+        return True
+


### PR DESCRIPTION
This PR provides an initial implementation of the BallDangerous decision. It evaluates whether the ball is in an area around the goal, which is defined by a parameter. 
The parameter has to be evaluated.
We might need a version which does not require global localization. but it would be quite hard to do this properly.
Of course, this is currently untested. :stuck_out_tongue: 