### PR TITLE
Improved kick decision

### DIFF
--- a/bitbots_body_behavior/config/body_behavior.yaml
+++ b/bitbots_body_behavior/config/body_behavior.yaml
@@ -34,6 +34,20 @@ behavior:
     # it is close enough to be kicked
     max_kick_distance: 0.3
 
+    # An area in which the ball can be kicked with the right foot
+    # defined by min/max x/y values in meters which represent ball positions relative to base_footprint
+    right_kick_min_x: 0
+    right_kick_min_y: 0
+    right_kick_max_x: 0.15
+    right_kick_max_y: 0.2
+
+    # An area in which the ball can be kicked with the left foot
+    # defined by min/max x/y values in meters which represent ball positions relative to base_footprint
+    left_kick_min_x: -0.15
+    left_kick_min_y: 0
+    left_kick_max_x: 0
+    left_kick_max_y: 0.2
+
     # defines the radius around the goal (in form of a box)
     # in this area, the goalie will react to the ball.
     # the radius is the margin around the goal to both y and the positive x directions

--- a/bitbots_body_behavior/config/body_behavior.yaml
+++ b/bitbots_body_behavior/config/body_behavior.yaml
@@ -36,16 +36,18 @@ behavior:
 
     # An area in which the ball can be kicked with the right foot
     # defined by min/max x/y values in meters which represent ball positions relative to base_footprint
+    # http://www.ros.org/reps/rep-0103.html#axis-orientation
     right_kick_min_x: 0
-    right_kick_min_y: 0
+    right_kick_min_y: -0.2
     right_kick_max_x: 0.15
-    right_kick_max_y: 0.2
+    right_kick_max_y: 0
 
     # An area in which the ball can be kicked with the left foot
     # defined by min/max x/y values in meters which represent ball positions relative to base_footprint
-    left_kick_min_x: -0.15
+    # http://www.ros.org/reps/rep-0103.html#axis-orientation
+    left_kick_min_x: 0
     left_kick_min_y: 0
-    left_kick_max_x: 0
+    left_kick_max_x: 0.15
     left_kick_max_y: 0.2
 
     # defines the radius around the goal (in form of a box)

--- a/bitbots_body_behavior/src/bitbots_body_behavior/actions/kick_ball.py
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/actions/kick_ball.py
@@ -1,34 +1,23 @@
+import rospy
 from dynamic_stack_decider.abstract_action_element import AbstractActionElement
 
 
 class KickBall(AbstractActionElement):
     def __init__(self, blackboard, dsd, parameters=None):
         super(KickBall, self).__init__(blackboard, dsd, parameters)
-        self.right_kick = 'kick_right'  # TODO get actual name of parameter from some config
+        if 'foot' not in parameters.keys():
+            # usually, we kick with thr right foot
+            self.kick = 'kick_right'  # TODO get actual name of parameter from some config
+        elif 'right' == parameters['foot']:
+            self.kick = 'kick_right'  # TODO get actual name of parameter from some config
+        elif 'left' == parameters['foot']:
+            self.kick = 'kick_left'  # TODO get actual name of parameter from some config
+        else:
+            rospy.logerr('The parameter \'{}\' could not be used to decide which foot should kick'.format(parameters['foot']))
 
     def perform(self, reevaluate=False):
         if not self.blackboard.animation.is_animation_busy():
-            self.blackboard.animation.play_animation(self.right_kick)
-
-
-class KickBallRight(AbstractActionElement):
-    def __init__(self, blackboard, dsd, parameters=None):
-        super(KickBallRight, self).__init__(blackboard, dsd, parameters)
-        self.right_kick = 'kick_right'  # TODO get actual name of parameter from some config
-
-    def perform(self, reevaluate=False):
-        if not self.blackboard.animation.is_animation_busy():
-            self.blackboard.animation.play_animation(self.right_kick)
-
-
-class KickBallLeft(AbstractActionElement):
-    def __init__(self, blackboard, dsd, parameters=None):
-        super(KickBallLeft, self).__init__(blackboard, dsd, parameters)
-        self.right_kick = 'kick_left'  # TODO get actual name of parameter from some config
-
-    def perform(self, reevaluate=False):
-        if not self.blackboard.animation.is_animation_busy():
-            self.blackboard.animation.play_animation(self.right_kick)
+            self.blackboard.animation.play_animation(self.kick)
 
 
 class KickBallVeryHard(AbstractActionElement):

--- a/bitbots_body_behavior/src/bitbots_body_behavior/actions/kick_ball.py
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/actions/kick_ball.py
@@ -6,7 +6,7 @@ class KickBall(AbstractActionElement):
     def __init__(self, blackboard, dsd, parameters=None):
         super(KickBall, self).__init__(blackboard, dsd, parameters)
         if 'foot' not in parameters.keys():
-            # usually, we kick with thr right foot
+            # usually, we kick with the right foot
             self.kick = 'kick_right'  # TODO get actual name of parameter from some config
         elif 'right' == parameters['foot']:
             self.kick = 'kick_right'  # TODO get actual name of parameter from some config

--- a/bitbots_body_behavior/src/bitbots_body_behavior/actions/kick_ball.py
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/actions/kick_ball.py
@@ -11,6 +11,26 @@ class KickBall(AbstractActionElement):
             self.blackboard.animation.play_animation(self.right_kick)
 
 
+class KickBallRight(AbstractActionElement):
+    def __init__(self, blackboard, dsd, parameters=None):
+        super(KickBallRight, self).__init__(blackboard, dsd, parameters)
+        self.right_kick = 'kick_right'  # TODO get actual name of parameter from some config
+
+    def perform(self, reevaluate=False):
+        if not self.blackboard.animation.is_animation_busy():
+            self.blackboard.animation.play_animation(self.right_kick)
+
+
+class KickBallLeft(AbstractActionElement):
+    def __init__(self, blackboard, dsd, parameters=None):
+        super(KickBallLeft, self).__init__(blackboard, dsd, parameters)
+        self.right_kick = 'kick_left'  # TODO get actual name of parameter from some config
+
+    def perform(self, reevaluate=False):
+        if not self.blackboard.animation.is_animation_busy():
+            self.blackboard.animation.play_animation(self.right_kick)
+
+
 class KickBallVeryHard(AbstractActionElement):
     def __init__(self, blackboard, dsd, parameters=None):
         super().__init__(blackboard, dsd, parameters)

--- a/bitbots_body_behavior/src/bitbots_body_behavior/decisions/ball_kick_area.py
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/decisions/ball_kick_area.py
@@ -1,0 +1,34 @@
+from dynamic_stack_decider.abstract_decision_element import AbstractDecisionElement
+
+
+class BallKickArea(AbstractDecisionElement):
+    def __init__(self, blackboard, dsd, parameters=None):
+        super(BallKickArea, self).__init__(blackboard, dsd, parameters)
+        self.max_kick_distance = self.blackboard.config['max_kick_distance']
+        self.right_kick_min_x = self.blackboard.config['right_kick_min_x']
+        self.right_kick_min_y = self.blackboard.config['right_kick_min_y']
+        self.right_kick_max_x = self.blackboard.config['right_kick_max_x']
+        self.right_kick_max_y = self.blackboard.config['right_kick_max_y']
+        self.left_kick_min_x = self.blackboard.config['left_kick_min_x']
+        self.left_kick_min_y = self.blackboard.config['left_kick_min_y']
+        self.left_kick_max_x = self.blackboard.config['left_kick_max_x']
+        self.left_kick_max_y = self.blackboard.config['left_kick_max_y']
+
+    def perform(self, reevaluate=False):
+        ball_position = self.blackboard.world_model.get_ball_position_uv()
+        if self.right_kick_min_x <= ball_position[0] <= self.right_kick_max_x and \
+           self.right_kick_min_y <= ball_position[1] <= self.right_kick_max_y:
+            return 'RIGHT'
+        if self.left_kick_min_x <= ball_position[0] <= self.left_kick_max_x and \
+           self.left_kick_min_y <= ball_position[1] <= self.left_kick_max_y:
+            return 'LEFT'
+        # TODO: areas for TURN RIGHT/LEFT/AROUND might be useful.
+        return 'FAR'
+
+    def get_reevaluate(self):
+        """
+        As the position of the ball relative to the robot changes even without actions of the robot,
+        this needs to be reevaluated.
+        :return: True. Always. Trust me.
+        """
+        return True

--- a/bitbots_body_behavior/src/bitbots_body_behavior/main.dsd
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/main.dsd
@@ -1,7 +1,7 @@
-#KickBall
+#GoAndKickBall
 $BallKickArea
-    LEFT --> @KickBallLeft
-    RIGHT --> @KickBallRight
+    LEFT --> @KickBall + foot:left
+    RIGHT --> @KickBall + foot:right
     FAR --> @GoToBall
 
 #GoalieBehavior

--- a/bitbots_body_behavior/src/bitbots_body_behavior/main.dsd
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/main.dsd
@@ -7,19 +7,19 @@ $BallKickArea
 #GoalieBehavior
 $BallSeen
     YES --> $BallDangerous
-        YES --> #KickBall
+        YES --> #GoAndKickBall
         NO --> @LookAtBall
     NO --> @SearchBall
 
 #OffenseBehavior
 $BallSeen
-    YES --> #KickBall
+    YES --> #GoAndKickBall
     NO --> @SearchBall
 
 #DefenseBehavior
 $BallSeen
     YES --> $BallClose
-        YES --> #KickBall
+        YES --> #GoAndKickBall
         NO --> @GoToDefensePosition
     NO --> @SearchBall
 

--- a/bitbots_body_behavior/src/bitbots_body_behavior/main.dsd
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/main.dsd
@@ -1,22 +1,19 @@
 #KickBall
-$AlignedToGoal
-    YES --> @KickBall
-    NO --> @AlignToGoal
+$BallKickArea
+    LEFT --> @KickBallLeft
+    RIGHT --> @KickBallRight
+    FAR --> @GoToBall
 
 #GoalieBehavior
 $BallSeen
     YES --> $BallDangerous
-        YES --> $BallClose
-            YES --> #KickBall
-            NO --> @GoToBall
+        YES --> #KickBall
         NO --> @LookAtBall
     NO --> @SearchBall
 
 #OffenseBehavior
 $BallSeen
-    YES --> $BallClose
-        YES --> #KickBall
-        NO --> @GoToBall
+    YES --> #KickBall
     NO --> @SearchBall
 
 #DefenseBehavior


### PR DESCRIPTION
The improved kick decision allows us to define an area for each foot in which the ball can be reached. The areas would replace the evaluation done solely based on the distance (independent to the direction) between robot and ball. 
In case the distance to the ball is too high, the decision returns 'FAR'. I do not like the fact, that therefore I had to move the goToBall stuff into the kickBall function. Thus, it will be harder to implement an alignment to something else than the opponent's goal. 
Maybe, the best way to handle this would be to rename the goToBall action to something like 'goToBallGoalOriented' to reflect the alignment and to rename 'kickBall' to 'kickBallToGoal'
This is not tested.