### PR TITLE
Add goal parts instead of goals

### DIFF
--- a/bitbots_blackboard/src/bitbots_blackboard/capsules/world_model_capsule.py
+++ b/bitbots_blackboard/src/bitbots_blackboard/capsules/world_model_capsule.py
@@ -139,15 +139,41 @@ class WorldModelCapsule:
 
 
 
-    def goal_callback(self, msg):
+    def goal_parts_callback(self, msg):
         # type: (GoalRelative) -> None
-        self.goal = msg
+        goal_parts = msg
         # todo: transform to base_footprint too!
         # adding a minor delay to timestamp to ease transformations.
-        self.goal.header.stamp = self.goal.header.stamp + rospy.Duration.from_sec(0.01)
-        goal_left_buffer = PointStamped(self.goal.header, self.goal.left_post)
-        goal_right_buffer = PointStamped(self.goal.header, self.goal.right_post)
-        self.goal_odom.header = self.goal.header
+        goal_parts.header.stamp = goal_parts.header.stamp + rospy.Duration.from_sec(0.01)
+
+        # Tuple(First Post, Second Post, Distance)
+        goal_combination = (-1,-1,-1)
+        # Enumerate all goalpost combinations, this also combines each post with itself,
+        # to get the special case that only one post was detected and the maximum distance is 0.
+        for first_post_id, first_post in enumerate(goal_parts.posts):
+            for second_post_id, second_post in enumerate(goal_parts.posts):
+                # Get the minimal angular difference between the two posts
+                angular_distance = abs((math.atan2(*first_post.foot_point) - math.atan2(*second_post.foot_point) + math.pi) % (2*math.pi) - math.pi)
+                # Set a new pair of posts if the distance is bigger than the previous ones
+                if angular_distance > goal_combination[2]:
+                    goal_combination = (first_post_id, second_post_id, angular_distance)
+        # Catch the case, that no posts are detected
+        if goal_combination[2] == -1:
+            return
+        # Define right and left post
+        first_post = goal_parts.posts[goal_combination[0]]
+        second_post = goal_parts.posts[goal_combination[1]]
+        if math.atan2(first_post.foot_point[1], first_post.foot_point[0]) > \
+                math.atan2(first_post.foot_point[1], first_post.foot_point[0]):
+            left_post = first_post
+            right_post = second_post
+        else:
+            left_post = second_post
+            right_post = first_post
+
+        goal_left_buffer = PointStamped(goal_parts.header, left_post.foot_point)
+        goal_right_buffer = PointStamped(goal_parts.header, right_post.foot_point)
+        self.goal_odom.header = goal_parts.header
         if goal_left_buffer.header.frame_id != 'odom':
             try:
                 self.goal_odom.left_post = self.tf_buffer.transform(goal_left_buffer, 'odom', timeout=rospy.Duration(0.2)).point

--- a/bitbots_blackboard/src/bitbots_blackboard/capsules/world_model_capsule.py
+++ b/bitbots_blackboard/src/bitbots_blackboard/capsules/world_model_capsule.py
@@ -173,6 +173,11 @@ class WorldModelCapsule:
 
         goal_left_buffer = PointStamped(goal_parts.header, left_post.foot_point)
         goal_right_buffer = PointStamped(goal_parts.header, right_post.foot_point)
+        
+        self.goal.header = goal_parts.header
+        self.goal.left_post = goal_left_buffer
+        self.goal.right_post = goal_right_buffer
+
         self.goal_odom.header = goal_parts.header
         if goal_left_buffer.header.frame_id != 'odom':
             try:

--- a/bitbots_body_behavior/src/bitbots_body_behavior/body_behavior.py
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/body_behavior.py
@@ -14,7 +14,7 @@ import rospy
 from geometry_msgs.msg import PoseWithCovarianceStamped
 from tf2_geometry_msgs import PoseStamped
 from humanoid_league_msgs.msg import BallRelative, GameState, HeadMode, Strategy, TeamData,\
-    PlayAnimationAction, GoalRelative, RobotControlState
+    PlayAnimationAction, GoalPartsRelative, RobotControlState
 
 from bitbots_blackboard.blackboard import BodyBlackboard
 from dynamic_stack_decider import dsd
@@ -38,7 +38,7 @@ if __name__ == "__main__":
 
     # TODO: callbacks away from the blackboard!
     rospy.Subscriber("ball_relative", BallRelative, D.blackboard.world_model.ball_callback)
-    rospy.Subscriber("goal_relative", GoalRelative, D.blackboard.world_model.goal_callback)
+    rospy.Subscriber("goal_parts_relative", GoalPartsRelative, D.blackboard.world_model.goal_parts_relative)
     rospy.Subscriber("gamestate", GameState, D.blackboard.gamestate.gamestate_callback)
     rospy.Subscriber("team_data", TeamData, D.blackboard.team_data.team_data_callback)
     rospy.Subscriber("amcl_pose", PoseWithCovarianceStamped, D.blackboard.world_model.position_callback)


### PR DESCRIPTION
Now the behavior processes goal parts (currently only the posts) instead of a goal message. This is necessary due to bit-bots/bitbots_vision#69. Now the world model capsule is also responsible to interpret the different goal posts as one goal.