### PR TITLE
body behavior: fixes stop

### DIFF
--- a/bitbots_blackboard/src/bitbots_blackboard/capsules/pathfinding_capsule.py
+++ b/bitbots_blackboard/src/bitbots_blackboard/capsules/pathfinding_capsule.py
@@ -3,6 +3,7 @@ import math
 
 import tf2_ros
 from geometry_msgs.msg import PoseStamped
+from actionlib_msgs.msg import GoalID
 from tf.transformations import euler_from_quaternion, quaternion_from_euler
 
 
@@ -14,6 +15,7 @@ class PathfindingCapsule:
         self.position_threshold = 0.3
         self.orientation_threshold = 10
         self.pathfinding_pub = None  # type: rospy.Publisher
+        self.pathfinding_cancel_pub = None  # type: rospy.Publisher
         self.goal = None  # type: PoseStamped
         self.current_pose = None # type: PoseStamped
 
@@ -82,3 +84,6 @@ class PathfindingCapsule:
 
     def get_current_pose(self):
         return self.current_pose
+
+    def cancel_goal(self):
+        self.pathfinding_cancel_pub.publish(GoalID())

--- a/bitbots_body_behavior/src/bitbots_body_behavior/actions/stand.py
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/actions/stand.py
@@ -8,14 +8,9 @@ class Stop(AbstractActionElement):
     """ This stops the robot's walking and pops itself when the robot stands """
 
     def perform(self, reevaluate=False):
-        stand_pose = PoseStamped()
-        stand_pose.header.stamp = rospy.Time.now()
-        stand_pose.header.frame_id = 'base_footprint'
-        stand_pose.pose.orientation.w = 1
-        self.blackboard.pathfinding.publish(stand_pose)
-        if not self.blackboard.blackboard.is_currently_walking():
-            self.pop()
-
+        self.blackboard.pathfinding.cancel_goal()
+        self.pop()
+        
 
 class StandAndWait(AbstractActionElement):
     """ This stops the robots walking and keeps standing """

--- a/bitbots_body_behavior/src/bitbots_body_behavior/body_behavior.py
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/body_behavior.py
@@ -16,6 +16,7 @@ from tf2_geometry_msgs import PoseStamped
 from humanoid_league_msgs.msg import BallRelative, GameState, HeadMode, Strategy, TeamData,\
     PlayAnimationAction, GoalPartsRelative, RobotControlState
 from move_base_msgs.msg import MoveBaseActionFeedback
+from actionlib_msgs.msg import GoalID
 
 from bitbots_blackboard.blackboard import BodyBlackboard
 from dynamic_stack_decider import dsd
@@ -28,6 +29,7 @@ if __name__ == "__main__":
     D.blackboard.team_data.strategy_sender = rospy.Publisher("strategy", Strategy, queue_size=2)
     D.blackboard.blackboard.head_pub = rospy.Publisher("head_mode", HeadMode, queue_size=10)
     D.blackboard.pathfinding.pathfinding_pub = rospy.Publisher('move_base_simple/goal', PoseStamped, queue_size=1)
+    D.blackboard.pathfinding.pathfinding_cancel_pub = rospy.Publisher('move_base/cancel', GoalID, queue_size=1)
 
     dirname = os.path.dirname(os.path.realpath(__file__))
 


### PR DESCRIPTION
We used to stop by setting our current position as goal position in the path finding. In contrast to the simulation, this does not work in reality (reality sucks) so now, an alternate implementation cancels the current goal in the move_base. 