### PR TITLE
body behavior: solve double kick bug

### DIFF
--- a/bitbots_blackboard/package.xml
+++ b/bitbots_blackboard/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
     <name>bitbots_blackboard</name>
-    <version>0.1.0</version>
+    <version>0.1.1</version>
     <description>The bitbots_blackboard is used to share information
         between the different classes in the behaviour. It consists
         of several capsules each for there own purpose. For example

--- a/bitbots_blackboard/src/bitbots_blackboard/capsules/world_model_capsule.py
+++ b/bitbots_blackboard/src/bitbots_blackboard/capsules/world_model_capsule.py
@@ -82,6 +82,10 @@ class WorldModelCapsule:
             self.ball_seen_time = rospy.Time.now()
             self.ball_seen = True
 
+    def forget_ball(self):
+        """Forget that we saw a ball"""
+        self.ball_seen_time = rospy.Time(0)
+        self.ball = PointStamped()
 
     ###########
     # ## Goal #

--- a/bitbots_body_behavior/package.xml
+++ b/bitbots_body_behavior/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bitbots_body_behavior</name>
-  <version>0.9.3</version>
+  <version>0.9.4</version>
   <description>The bitbots_body_behavior package determines the
         behavior of the robot including strategy decisions and
         kick or walk actions. The node controls the walking indirecty via


### PR DESCRIPTION
solves the bug of doing double kick by forgetting, that we saw the ball after performing a kick. previously the robot did another kick, since it thought that the ball is still there, since the time was not so long since it saw the ball

## Necessary checks
- [x] Update package version
- [ ] Run linters
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Test on your machine
- [ ] Test on the robot

