### PR TITLE
Config values for faster tracking

### DIFF
--- a/bitbots_head_behavior/config/head_config.yaml
+++ b/bitbots_head_behavior/config/head_config.yaml
@@ -88,8 +88,8 @@ behavior:
 
     # These values describe the minimal required delta between current joint states and target joint states in degrees
     # to reduce unnecessary movement due to noise in the detection of the BallRelative.
-    ball_tracking_min_pan_delta: 3
-    ball_tracking_min_tilt_delta: 3
+    ball_tracking_min_pan_delta: 1.5
+    ball_tracking_min_tilt_delta: 1.5
 
     # Positions for static head modes
     look_down_position: [0, -65]

--- a/bitbots_head_behavior/package.xml
+++ b/bitbots_head_behavior/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bitbots_head_behavior</name>
-  <version>0.2.4</version>
+  <version>0.2.5</version>
   <description>The bitbots_head_behavior package is used to control the behavior of the head.
       The head searches for balls, goals and lines and tracks them. The head behavior can be
       controlled by the /head_duty topic and publishes the head motion in the /head_motor_goals topic.
@@ -12,15 +12,15 @@
   <license>MIT</license>
 
   <buildtool_depend>catkin</buildtool_depend>
-  
+
   <exec_depend>rospy</exec_depend>
-  
+
   <depend>std_msgs</depend>
   <exec_depend>humanoid_league_msgs</exec_depend>
   <exec_depend>dynamic_stack_decider</exec_depend>
-  <exec_depend>bitbots_blackboard</exec_depend>  
+  <exec_depend>bitbots_blackboard</exec_depend>
   <exec_depend>bio_ik_service</exec_depend>
-  
+
   <export>
     <rosdoc config="rosdoc.yaml"/>
     <bitbots_documentation>

--- a/bitbots_head_behavior/src/bitbots_head_behavior/actions/look_at.py
+++ b/bitbots_head_behavior/src/bitbots_head_behavior/actions/look_at.py
@@ -63,7 +63,7 @@ class AbstractLookAt(AbstractActionElement):
         current_head_pan, current_head_tilt = self.blackboard.head_capsule.get_head_position()
         if abs(current_head_pan - head_pan) >= math.radians(min_pan_delta) or \
                 abs(current_head_tilt - head_tilt) >= math.radians(min_tilt_delta):
-            self.blackboard.head_capsule.send_motor_goals(head_pan, head_tilt, pan_speed=2.0, tilt_speed=2.0)
+            self.blackboard.head_capsule.send_motor_goals(head_pan, head_tilt, pan_speed=3.0, tilt_speed=3.0)
 
 
 class LookDirection(AbstractLookAt):

--- a/bitbots_head_behavior/src/bitbots_head_behavior/head_node.py
+++ b/bitbots_head_behavior/src/bitbots_head_behavior/head_node.py
@@ -22,7 +22,7 @@ def run(dsd):
 
     :returns: Never
     """
-    rate = rospy.Rate(5)
+    rate = rospy.Rate(15)
     while not rospy.is_shutdown():
         dsd.update()
         rate.sleep()


### PR DESCRIPTION
With the increased vision fps, we can track balls quite faster. To do this, the head behavior speed needs to be increased slightly.

## Proposed changes
- Increase DSD refresh rate to roughly the framerate of the vision
- With the old tf buffer fixed, the min delta values for a movement can also be increased.
- Turn up the motor speeds.

## Necessary checks
- [x] Update package version
- [x] Run linters
- [x] Run `catkin build`
- [ ] ~~Write documentation~~
- [ ] ~~Test on your machine~~
- [x] Test on the robot

