### PR TITLE
use kick launch file in rviz_behavior_test

### DIFF
--- a/bitbots_body_behavior/launch/rviz_behavior_test.launch
+++ b/bitbots_body_behavior/launch/rviz_behavior_test.launch
@@ -16,8 +16,7 @@
     <include file="$(find humanoid_league_interactive_marker)/launch/interactive_marker.launch" />
 
     <node name="motor_goals_viz_helper" pkg="bitbots_bringup" type="motor_goals_viz_helper.py"/>
-    <!-- TODO: replace this with the launch file when one exists -->
-    <node name="dynamic_kick" pkg="bitbots_dynamic_kick" type="KickNode" output="screen" />
+    <include file="$(find bitbots_dynamic_kick)/launch/dynamic_kick.launch" />
 
     <node name="show_world_model_objects" pkg="bitbots_body_behavior" type="show_world_model_objects.py"
           output="screen"/>

--- a/bitbots_body_behavior/package.xml
+++ b/bitbots_body_behavior/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bitbots_body_behavior</name>
-  <version>0.9.8</version>
+  <version>0.9.9</version>
   <description>The bitbots_body_behavior package determines the
         behavior of the robot including strategy decisions and
         kick or walk actions. The node controls the walking indirecty via


### PR DESCRIPTION
## Proposed changes
Currently, only the kick node is included in the rviz_behavior_test launch file. This should be changed to the kick launch file.

## Related issues
https://github.com/bit-bots/bitbots_motion/pull/150

## Necessary checks
- [x] Update package version
- [x] Run `catkin build`
- [ ] ~Write documentation~
- [ ] ~Create issues for future work~
- [x] Test on your machine
- [ ] ~Test on the robot~
- [x] Put the PR on our Project board

