### PR TITLE
head behavior: add collision checking module

### DIFF
--- a/bitbots_blackboard/src/bitbots_blackboard/capsules/head_capsule.py
+++ b/bitbots_blackboard/src/bitbots_blackboard/capsules/head_capsule.py
@@ -90,7 +90,7 @@ class HeadCapsule:
         if self.collision_checker.check_collision():
             pan = round(math.degrees(pan_position), 2)
             tilt = round(math.degrees(tilt_position), 2)
-            rospy.logwarn(f"Colliding head position: {pan}, {tilt}. Not moving.")
+            rospy.logwarn(f"Colliding head position: {pan}°, {tilt}°. Not moving.")
             return False
         else:
             self.pos_msg.positions = pan_position, tilt_position

--- a/bitbots_blackboard/src/bitbots_blackboard/capsules/head_capsule.py
+++ b/bitbots_blackboard/src/bitbots_blackboard/capsules/head_capsule.py
@@ -1,3 +1,4 @@
+from io import BytesIO
 import rospy
 from humanoid_league_msgs.msg import HeadMode as HeadModeMsg
 from bitbots_msgs.msg import JointCommand
@@ -114,6 +115,9 @@ class HeadCapsule:
     ##################
 
     def joint_state_callback(self, msg):
+        buf = BytesIO()
+        msg.serialize(buf)
+        self.collision_checker.set_joint_states(buf.getvalue())
         head_pan = msg.position[msg.name.index('HeadPan')]
         head_tilt = msg.position[msg.name.index('HeadTilt')]
         self.current_head_position = [head_pan, head_tilt]

--- a/bitbots_blackboard/src/bitbots_blackboard/capsules/head_capsule.py
+++ b/bitbots_blackboard/src/bitbots_blackboard/capsules/head_capsule.py
@@ -1,4 +1,5 @@
 from io import BytesIO
+import math
 import rospy
 from humanoid_league_msgs.msg import HeadMode as HeadModeMsg
 from bitbots_msgs.msg import JointCommand
@@ -87,7 +88,7 @@ class HeadCapsule:
         # Check for collision
         self.collision_checker.set_head_motors(pan_position, tilt_position)
         if self.collision_checker.check_collision():
-            rospy.logwarn(f"Colliding head position: {pan_position}, {tilt_position}. Not moving.")
+            rospy.logwarn(f"Colliding head position: {math.degrees(pan_position)}, {math.degrees(tilt_position)}. Not moving.")
             return False
         else:
             self.pos_msg.positions = pan_position, tilt_position

--- a/bitbots_blackboard/src/bitbots_blackboard/capsules/head_capsule.py
+++ b/bitbots_blackboard/src/bitbots_blackboard/capsules/head_capsule.py
@@ -88,7 +88,9 @@ class HeadCapsule:
         # Check for collision
         self.collision_checker.set_head_motors(pan_position, tilt_position)
         if self.collision_checker.check_collision():
-            rospy.logwarn(f"Colliding head position: {math.degrees(pan_position)}, {math.degrees(tilt_position)}. Not moving.")
+            pan = round(math.degrees(pan_position), 2)
+            tilt = round(math.degrees(tilt_position), 2)
+            rospy.logwarn(f"Colliding head position: {pan}, {tilt}. Not moving.")
             return False
         else:
             self.pos_msg.positions = pan_position, tilt_position

--- a/bitbots_blackboard/src/bitbots_blackboard/capsules/head_capsule.py
+++ b/bitbots_blackboard/src/bitbots_blackboard/capsules/head_capsule.py
@@ -65,7 +65,7 @@ class HeadCapsule:
         :param clip: clip the motor values at the maximum value. This should almost always be true.
         :param current_pan_position: Current pan joint state for better interpolation (only active if both joints are set).
         :param current_tilt_position: Current tilt joint state for better interpolation (only active if both joints are set).
-        :return:
+        :return: False if the target position collides, True otherwise
         """
         rospy.logdebug("target pan/tilt: {}/{}".format(pan_position, tilt_position))
 
@@ -87,11 +87,13 @@ class HeadCapsule:
         self.collision_checker.set_head_motors(pan_position, tilt_position)
         if self.collision_checker.check_collision():
             rospy.logwarn(f"Colliding head position: {pan_position}, {tilt_position}. Not moving.")
+            return False
         else:
             self.pos_msg.positions = pan_position, tilt_position
             self.pos_msg.velocities = [pan_speed, tilt_speed]
             self.pos_msg.header.stamp = rospy.Time.now()
             self.position_publisher.publish(self.pos_msg)
+            return True
 
     def pre_clip(self, pan, tilt):
         """

--- a/bitbots_head_behavior/CMakeLists.txt
+++ b/bitbots_head_behavior/CMakeLists.txt
@@ -9,7 +9,7 @@ else()
     find_package(Boost REQUIRED COMPONENTS python)
 endif()
 
-find_package (PythonLibs COMPONENTS Interpreter Development)
+find_package(PythonLibs COMPONENTS Interpreter Development)
 find_package(catkin REQUIRED COMPONENTS std_msgs bitbots_docs moveit_core moveit_ros_robot_interaction moveit_ros_move_group)
 
 catkin_python_setup()

--- a/bitbots_head_behavior/CMakeLists.txt
+++ b/bitbots_head_behavior/CMakeLists.txt
@@ -1,10 +1,43 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(bitbots_head_behavior)
 
-find_package(catkin REQUIRED COMPONENTS std_msgs bitbots_docs)
+find_package(Eigen3 REQUIRED)
+find_package(PythonLibs)
+if(PYTHONLIBS_VERSION_STRING VERSION_LESS "3.8")
+    find_package(Boost REQUIRED COMPONENTS python3)
+else()
+    find_package(Boost REQUIRED COMPONENTS python)
+endif()
+
+find_package (PythonLibs COMPONENTS Interpreter Development)
+find_package(catkin REQUIRED COMPONENTS std_msgs bitbots_docs moveit_core moveit_ros_robot_interaction moveit_ros_move_group)
 
 catkin_python_setup()
 
-catkin_package()
+catkin_package(
+    INCLUDE_DIRS include
+    LIBRARIES ${PROJECT_NAME}
+    DEPENDS EIGEN3
+)
 
 enable_bitbots_docs()
+
+include_directories(
+        include
+        ${catkin_INCLUDE_DIRS}
+        ${Boost_INCLUDE_DIRS}
+        ${EIGEN3_INCLUDE_DIRS}
+        ${PYTHON_INCLUDE_DIRS}
+)
+
+# create the lib
+add_library(collision_checker SHARED src/collision_checker.cpp)
+add_dependencies(collision_checker ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+# link
+target_link_libraries(collision_checker ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${CODE_LIBRARIES})
+
+set_target_properties(collision_checker PROPERTIES
+        PREFIX ""
+        LIBRARY_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION}
+)

--- a/bitbots_head_behavior/config/head_config.yaml
+++ b/bitbots_head_behavior/config/head_config.yaml
@@ -27,7 +27,7 @@ behavior:
 
         # Max values for the search pattern
         pan_max: [120, -120]
-        tilt_max: [0, -70]
+        tilt_max: [0, -60]
 
         # Number of scan lines for the search pattern
         scan_lines: 4

--- a/bitbots_head_behavior/include/bitbots_head_behavior/collision_checker.h
+++ b/bitbots_head_behavior/include/bitbots_head_behavior/collision_checker.h
@@ -8,11 +8,13 @@
 #include <moveit/robot_model_loader/robot_model_loader.h>
 #include <moveit/robot_model/robot_model.h>
 #include <moveit/robot_state/robot_state.h>
+#include <sensor_msgs/JointState.h>
 
 class CollisionChecker {
  public:
   CollisionChecker();
   void set_head_motors(double pan, double tilt);
+  void set_joint_states(std::string msg);
   bool check_collision();
 
  private:

--- a/bitbots_head_behavior/include/bitbots_head_behavior/collision_checker.h
+++ b/bitbots_head_behavior/include/bitbots_head_behavior/collision_checker.h
@@ -1,4 +1,3 @@
-
 #include <Python.h>
 #include <boost/python.hpp>
 #include <ros/ros.h>

--- a/bitbots_head_behavior/include/bitbots_head_behavior/collision_checker.h
+++ b/bitbots_head_behavior/include/bitbots_head_behavior/collision_checker.h
@@ -1,0 +1,23 @@
+
+#include <Python.h>
+#include <boost/python.hpp>
+#include <ros/ros.h>
+#include <map>
+#include <iostream>
+#include <moveit/planning_scene/planning_scene.h>
+#include <moveit/robot_model_loader/robot_model_loader.h>
+#include <moveit/robot_model/robot_model.h>
+#include <moveit/robot_state/robot_state.h>
+
+class CollisionChecker {
+ public:
+  CollisionChecker();
+  void set_head_motors(double pan, double tilt);
+  bool check_collision();
+
+ private:
+  planning_scene::PlanningScenePtr planning_scene_;
+  robot_model_loader::RobotModelLoaderPtr robot_model_loader_;
+  robot_model::RobotModelPtr robot_model_;
+  robot_state::RobotStatePtr robot_state_;
+};

--- a/bitbots_head_behavior/launch/head_behavior_standalone.launch
+++ b/bitbots_head_behavior/launch/head_behavior_standalone.launch
@@ -1,12 +1,8 @@
 <?xml version="1.0"?>
 <launch>
-
     <arg name="depends_only" default="false" />
-    <arg name="wolfgang" default="true" />
     
-    <include file="$(find bitbots_bringup)/launch/load_robot_description.launch">
-        <arg name="wolfgang" value="$(arg wolfgang)"/>   
-    </include>
+    <include file="$(find bitbots_bringup)/launch/load_robot_description.launch" />
 
     <include file="$(find bitbots_head_behavior)/launch/head_behavior.launch">
         <arg name="depends_only" value="$(arg depends_only)"/>

--- a/bitbots_head_behavior/launch/test.launch
+++ b/bitbots_head_behavior/launch/test.launch
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<launch>
+    <arg name="sim" default="false"/>
+    <group unless="$(arg sim)">
+        <include file="$(find bitbots_ros_control)/launch/ros_control.launch" />
+    </group>
+
+    <include file="$(find bitbots_bringup)/launch/load_robot_description.launch" />
+
+    <include file="$(find bitbots_vision)/launch/vision_startup.launch" />
+
+
+    <arg name="depends_only" default="false" />
+    <rosparam command="load" file="$(find bitbots_head_behavior)/config/head_config.yaml"/>
+
+    <node name="bio_ik_service" pkg="bio_ik_service" type="bio_ik_service"  output="screen"/>
+
+    <node unless="$(arg depends_only)" name="head_behavior" pkg="bitbots_head_behavior" type="head_node.py"  output="screen">
+            <remap from="/head_motor_goals" to="/DynamixelController/command"/>
+    </node>
+
+</launch>

--- a/bitbots_head_behavior/launch/test.launch
+++ b/bitbots_head_behavior/launch/test.launch
@@ -9,6 +9,8 @@
 
     <include file="$(find bitbots_vision)/launch/vision_startup.launch" />
 
+    <include file="$(find humanoid_league_transform)/launch/transformer.launch" />
+
 
     <arg name="depends_only" default="false" />
     <rosparam command="load" file="$(find bitbots_head_behavior)/config/head_config.yaml"/>

--- a/bitbots_head_behavior/package.xml
+++ b/bitbots_head_behavior/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bitbots_head_behavior</name>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
   <description>The bitbots_head_behavior package is used to control the behavior of the head.
       The head searches for balls, goals and lines and tracks them. The head behavior can be
       controlled by the /head_duty topic and publishes the head motion in the /head_motor_goals topic.

--- a/bitbots_head_behavior/src/bitbots_head_behavior/actions/search_pattern.py
+++ b/bitbots_head_behavior/src/bitbots_head_behavior/actions/search_pattern.py
@@ -103,6 +103,7 @@ class AbstractSearchPattern(AbstractActionElement):
             current_tilt_position=current_head_tilt)
 
         if not success:
+            rospy.logwarn(f"Pattern position {self.index} collided, the pattern should probably be changed")
             # Try the next pattern position
             self.index += 1
         else:

--- a/bitbots_head_behavior/src/bitbots_head_behavior/actions/search_pattern.py
+++ b/bitbots_head_behavior/src/bitbots_head_behavior/actions/search_pattern.py
@@ -94,7 +94,7 @@ class AbstractSearchPattern(AbstractActionElement):
         head_tilt = math.radians(head_tilt)
         rospy.logdebug("Searching at {}, {}".format(head_pan, head_tilt))
 
-        self.blackboard.head_capsule.send_motor_goals(
+        success = self.blackboard.head_capsule.send_motor_goals(
             head_pan,
             head_tilt,
             pan_speed=self.pan_speed,
@@ -102,11 +102,15 @@ class AbstractSearchPattern(AbstractActionElement):
             current_pan_position=current_head_pan,
             current_tilt_position=current_head_tilt)
 
-        distance = math.sqrt((current_head_pan - head_pan) ** 2 + (current_head_tilt - head_tilt) ** 2)
+        if not success:
+            # Try the next pattern position
+            self.index += 1
+        else:
+            distance = math.sqrt((current_head_pan - head_pan) ** 2 + (current_head_tilt - head_tilt) ** 2)
 
-        # Increment index when position is reached
-        if distance < math.radians(self.threshold):
-            self.index = self.index + 1
+            # Increment index when position is reached
+            if distance < math.radians(self.threshold):
+                self.index += 1
 
 
 class BallSearchPattern(AbstractSearchPattern):

--- a/bitbots_head_behavior/src/bitbots_head_behavior/actions/search_recent_ball.py
+++ b/bitbots_head_behavior/src/bitbots_head_behavior/actions/search_recent_ball.py
@@ -93,20 +93,23 @@ class SearchRecentBall(AbstractLookAt):
         head_motor_goal_pan, head_motor_goal_tilt = \
             self.blackboard.head_capsule.pre_clip(head_motor_goal_pan, head_motor_goal_tilt)
 
-        self.blackboard.head_capsule.send_motor_goals(
+        success = self.blackboard.head_capsule.send_motor_goals(
             head_motor_goal_pan,
             head_motor_goal_tilt,
             pan_speed=self._pan_speed,
             tilt_speed=self._tilt_speed)
 
-        # Distance between the current and the goal position
-        distance = math.sqrt(
-            (current_head_pan - head_motor_goal_pan) ** 2 +
-            (current_head_tilt - head_motor_goal_tilt) ** 2)
-
-
-        # Increment index when position is reached
-        if distance < math.radians(self._threshold):
+        if not success:
+            # Try the next pattern position
             self.index += 1
+        else:
+            # Distance between the current and the goal position
+            distance = math.sqrt(
+                (current_head_pan - head_motor_goal_pan) ** 2 +
+                (current_head_tilt - head_motor_goal_tilt) ** 2)
+
+            # Increment index when position is reached
+            if distance < math.radians(self._threshold):
+                self.index += 1
 
         self.first_perform = False

--- a/bitbots_head_behavior/src/bitbots_head_behavior/head_node.py
+++ b/bitbots_head_behavior/src/bitbots_head_behavior/head_node.py
@@ -14,6 +14,7 @@ from humanoid_league_msgs.msg import HeadMode as HeadModeMsg, PoseWithCertainty,
 from bitbots_msgs.msg import JointCommand
 from sensor_msgs.msg import JointState
 from std_msgs.msg import Header
+from moveit_ros_planning_interface._moveit_roscpp_initializer import roscpp_init, roscpp_shutdown
 
 
 def run(dsd):
@@ -26,6 +27,8 @@ def run(dsd):
     while not rospy.is_shutdown():
         dsd.update()
         rate.sleep()
+    # Also stop cpp node
+    roscpp_shutdown()
 
 
 def init():
@@ -34,6 +37,9 @@ def init():
     blackboard, dsd, rostopic subscriber
     """
     rospy.init_node('head_behavior')
+    # This is a general purpose initialization function provided by moved
+    # It is used to correctly initialize roscpp which is used in the collision checker module
+    roscpp_init('collision_checker', [])
     blackboard = HeadBlackboard()
 
     rospy.Subscriber('/head_mode', HeadModeMsg, blackboard.head_capsule.head_mode_callback, queue_size=1)

--- a/bitbots_head_behavior/src/collision_checker.cpp
+++ b/bitbots_head_behavior/src/collision_checker.cpp
@@ -1,0 +1,33 @@
+#include <bitbots_head_behavior/collision_checker.h>
+
+CollisionChecker::CollisionChecker() {
+  std::map<std::string, std::string> empty;
+  ros::init(empty, "collision_checker", ros::init_options::AnonymousName);
+  robot_model_loader_.reset(new robot_model_loader::RobotModelLoader("/robot_description", false));
+  robot_model_ = robot_model_loader_->getModel();
+  planning_scene_.reset(new planning_scene::PlanningScene(robot_model_));
+  robot_state_.reset(new robot_state::RobotState(robot_model_));
+  robot_state_->setToDefaultValues();
+}
+
+void CollisionChecker::set_head_motors(double pan, double tilt) {
+  robot_state_->setJointPositions("HeadPan", &pan);
+  robot_state_->setJointPositions("HeadTilt", &tilt);
+}
+
+bool CollisionChecker::check_collision() {
+  collision_detection::CollisionRequest req;
+  collision_detection::CollisionResult res;
+  collision_detection::AllowedCollisionMatrix acm = planning_scene_->getAllowedCollisionMatrix();
+  planning_scene_->checkCollision(req, res, *robot_state_, acm);
+  return res.collision;
+}
+
+BOOST_PYTHON_MODULE(collision_checker)
+    {
+        using namespace boost::python;
+
+        class_<CollisionChecker>("CollisionChecker", init<>())
+        .def("set_head_motors", &CollisionChecker::set_head_motors, (arg("pan"), arg("tilt")), "Set the current pan and tilt moter values [radian]")
+        .def("check_collision", &CollisionChecker::check_collision, "Returns true if the head collides, else false");
+    }

--- a/bitbots_head_behavior/src/collision_checker.cpp
+++ b/bitbots_head_behavior/src/collision_checker.cpp
@@ -1,5 +1,19 @@
 #include <bitbots_head_behavior/collision_checker.h>
 
+/* Read a ROS message from a serialized string. */
+template<typename M>
+M from_python(const std::string &str_msg) {
+  size_t serial_size = str_msg.size();
+  boost::shared_array<uint8_t> buffer(new uint8_t[serial_size]);
+  for (size_t i = 0; i < serial_size; ++i) {
+    buffer[i] = str_msg[i];
+  }
+  ros::serialization::IStream stream(buffer.get(), serial_size);
+  M msg;
+  ros::serialization::Serializer<M>::read(stream, msg);
+  return msg;
+}
+
 CollisionChecker::CollisionChecker() {
   std::map<std::string, std::string> empty;
   ros::init(empty, "collision_checker", ros::init_options::AnonymousName);
@@ -13,6 +27,13 @@ CollisionChecker::CollisionChecker() {
 void CollisionChecker::set_head_motors(double pan, double tilt) {
   robot_state_->setJointPositions("HeadPan", &pan);
   robot_state_->setJointPositions("HeadTilt", &tilt);
+}
+
+void CollisionChecker::set_joint_states(std::string msg) {
+  sensor_msgs::JointState joint_states = from_python<sensor_msgs::JointState>(msg);
+  for (int i = 0; i < joint_states.name.size(); ++i) {
+    robot_state_->setJointPositions(joint_states.name[i], &joint_states.position[i]);
+  }
 }
 
 bool CollisionChecker::check_collision() {
@@ -29,5 +50,6 @@ BOOST_PYTHON_MODULE(collision_checker)
 
         class_<CollisionChecker>("CollisionChecker", init<>())
         .def("set_head_motors", &CollisionChecker::set_head_motors, (arg("pan"), arg("tilt")), "Set the current pan and tilt moter values [radian]")
+        .def("set_joint_states", &CollisionChecker::set_joint_states, "Set the current joint states")
         .def("check_collision", &CollisionChecker::check_collision, "Returns true if the head collides, else false");
     }

--- a/bitbots_head_behavior/src/collision_checker.cpp
+++ b/bitbots_head_behavior/src/collision_checker.cpp
@@ -20,7 +20,7 @@ CollisionChecker::CollisionChecker() {
   planning_scene_.reset(new planning_scene::PlanningScene(robot_model_));
   robot_state_.reset(new robot_state::RobotState(robot_model_));
   robot_state_->setToDefaultValues();
-  ROS_INFO("Collision checker setup finished\n");
+  ROS_INFO("Collision checker setup finished");
 }
 
 void CollisionChecker::set_head_motors(double pan, double tilt) {

--- a/bitbots_head_behavior/src/collision_checker.cpp
+++ b/bitbots_head_behavior/src/collision_checker.cpp
@@ -15,13 +15,12 @@ M from_python(const std::string &str_msg) {
 }
 
 CollisionChecker::CollisionChecker() {
-  std::map<std::string, std::string> empty;
-  ros::init(empty, "collision_checker", ros::init_options::AnonymousName);
   robot_model_loader_.reset(new robot_model_loader::RobotModelLoader("/robot_description", false));
   robot_model_ = robot_model_loader_->getModel();
   planning_scene_.reset(new planning_scene::PlanningScene(robot_model_));
   robot_state_.reset(new robot_state::RobotState(robot_model_));
   robot_state_->setToDefaultValues();
+  ROS_INFO("Collision checker setup finished\n");
 }
 
 void CollisionChecker::set_head_motors(double pan, double tilt) {


### PR DESCRIPTION
## Proposed changes
This pull request introduces a cpp python module that can check for collisions using MoveIt. When a collision occurs, the head stops moving. In general, it works very well. There are still two issues:

- The collision model of the head should be adapted to include the part between the sides just in front of the camera. Currently, the head can get stuck when a bumper is in that space because it can no longer move away.
- Collisions with the arms are not detected yet. This would be possible by listening to `/joint_states`.

The PR is ready to be tested on the robot (I tested it in rViz).

## Related issues
The pull request closes #55.

## Necessary checks
- [x] Update package version
- [x] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

