### PR TITLE
BodyBehavior: localization precision measurement

### DIFF
--- a/bitbots_blackboard/package.xml
+++ b/bitbots_blackboard/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
     <name>bitbots_blackboard</name>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <description>The bitbots_blackboard is used to share information
         between the different classes in the behaviour. It consists
         of several capsules each for there own purpose. For example

--- a/bitbots_blackboard/src/bitbots_blackboard/blackboard.py
+++ b/bitbots_blackboard/src/bitbots_blackboard/blackboard.py
@@ -24,7 +24,7 @@ class BodyBlackboard:
         self.animation = AnimationCapsule()
         self.kick = KickCapsule(self)
         self.pathfinding = PathfindingCapsule()
-        self.world_model = WorldModelCapsule(self.field_length, self.field_width, self.goal_width)
+        self.world_model = WorldModelCapsule(self.config, self.field_length, self.field_width, self.goal_width)
         self.team_data = TeamDataCapsule()
 
 

--- a/bitbots_blackboard/src/bitbots_blackboard/blackboard.py
+++ b/bitbots_blackboard/src/bitbots_blackboard/blackboard.py
@@ -32,6 +32,6 @@ class HeadBlackboard:
     def __init__(self):
         self.config = rospy.get_param("behavior/head")
         self.head_capsule = HeadCapsule(self)
-        self.world_model = WorldModelCapsule(6, 9, 2.6)  # TODO move this to a good place
+        self.world_model = WorldModelCapsule(self.config, 6, 9, 2.6)  # TODO move this to a good place
         rospy.wait_for_service('/bio_ik/get_bio_ik')
         self.bio_ik = rospy.ServiceProxy('/bio_ik/get_bio_ik', GetIK)

--- a/bitbots_blackboard/src/bitbots_blackboard/capsules/world_model_capsule.py
+++ b/bitbots_blackboard/src/bitbots_blackboard/capsules/world_model_capsule.py
@@ -248,9 +248,9 @@ class WorldModelCapsule:
         return self.pose.pose.pose.position.x, self.pose.pose.pose.position.y, theta
 
     def get_localization_precision(self):
-        x_sdev = self.pose.pose.covariance[0]  # position 0,0 in a 2D-matrix
-        y_sdev = self.pose.pose.covariance[7]  # position 1,1 in a 2D-matrix
-        theta_sdev = self.pose.pose.covariance[35]  # position 5,5 in a 2D-matrix
+        x_sdev = self.pose.pose.covariance[0]  # position 0,0 in a 6x6-matrix
+        y_sdev = self.pose.pose.covariance[7]  # position 1,1 in a 6x6-matrix
+        theta_sdev = self.pose.pose.covariance[35]  # position 5,5 in a 6x6-matrix
         return (x_sdev, y_sdev, theta_sdev)
 
     def localization_precision_in_threshold(self) -> bool:

--- a/bitbots_blackboard/src/bitbots_blackboard/capsules/world_model_capsule.py
+++ b/bitbots_blackboard/src/bitbots_blackboard/capsules/world_model_capsule.py
@@ -254,8 +254,8 @@ class WorldModelCapsule:
         return (x_sdev, y_sdev, theta_sdev)
 
     def localization_precision_in_threshold(self) -> bool:
-        # Check whether we recieved a message in the last pose_lost_time seconds.
-        if rospy.Time.now() - self.pose.header.stamp > self.config['pose_lost_time']:
+        # Check whether we received a message in the last pose_lost_time seconds.
+        if rospy.Time.now() - self.pose.header.stamp > rospy.Duration.from_sec(self.config['pose_lost_time']):
             return False
         # get the standard deviation values of the covariance matrix
         precision = self.get_localization_precision()

--- a/bitbots_blackboard/src/bitbots_blackboard/capsules/world_model_capsule.py
+++ b/bitbots_blackboard/src/bitbots_blackboard/capsules/world_model_capsule.py
@@ -32,7 +32,8 @@ class GoalRelative:
 
 
 class WorldModelCapsule:
-    def __init__(self, field_length, field_width, goal_width):
+    def __init__(self, config, field_length, field_width, goal_width):
+        self.config = config
         self.position = PoseWithCovarianceStamped()
         self.tf_buffer = tf2.Buffer(cache_time=rospy.Duration(30))
         self.tf_listener = tf2.TransformListener(self.tf_buffer)
@@ -268,3 +269,17 @@ class WorldModelCapsule:
 
     def position_callback(self, pos: PoseWithCovarianceStamped):
         self.position = pos
+
+    def get_localization_position_precision(self):
+        x_sdev = self.position.pose.covariance[0]  # position 0,0 in a 2D-matrix
+        y_sdev = self.position.pose.covariance[7]  # position 1,1 in a 2D-matrix
+        theta_sdev = self.position.pose.covariance[35]  # position 5,5 in a 2D-matrix
+        return (x_sdev, y_sdev, theta_sdev)
+
+    def localization_position_precision_in_threshold(self):
+        precision = self.get_localization_position_precision()
+        return precision[0] < self.config['x_sdev'] and \
+               precision[1] < self.config['y_sdev'] and \
+               precision[2] < self.config['theta_sdev']
+
+

--- a/bitbots_body_behavior/config/body_behavior.yaml
+++ b/bitbots_body_behavior/config/body_behavior.yaml
@@ -8,7 +8,7 @@ behavior:
 
     # When False, the behavior will use a simple fallback mode in which only detected image features are
     # used for decision making
-    use_localization: false
+    use_localization: true
 
     # Position format:
     #      y

--- a/bitbots_body_behavior/config/body_behavior.yaml
+++ b/bitbots_body_behavior/config/body_behavior.yaml
@@ -94,9 +94,13 @@ behavior:
       topic: "/dynamic_kick"
 
     # the maximal allowed standard deviation of the localization pose.
-    position_precision_threshold:
+    pose_precision_threshold:
       x_sdev: 0.3
       y_sdev: 0.3
       theta_sdev: 0.1
+
+    # maximum amount of time after which a localization pose is dropped.
+    # (This should not happen unless the localization has died. RIP in this case.)
+    pose_lost_time: 10
 
 role: "offense"

--- a/bitbots_body_behavior/config/body_behavior.yaml
+++ b/bitbots_body_behavior/config/body_behavior.yaml
@@ -93,4 +93,10 @@ behavior:
       # base topic under which an actionserver listens for KickAction messages
       topic: "/dynamic_kick"
 
+    # the maximal allowed standard deviation of the localization pose.
+    position_precision_threshold:
+      x_sdev: 0.3
+      y_sdev: 0.3
+      theta_sdev: 0.1
+
 role: "offense"

--- a/bitbots_body_behavior/package.xml
+++ b/bitbots_body_behavior/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bitbots_body_behavior</name>
-  <version>1.1.0</version>
+  <version>1.2.0</version>
   <description>The bitbots_body_behavior package determines the
         behavior of the robot including strategy decisions and
         kick or walk actions. The node controls the walking indirecty via

--- a/bitbots_body_behavior/src/bitbots_body_behavior/body_behavior.py
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/body_behavior.py
@@ -44,7 +44,7 @@ if __name__ == "__main__":
     rospy.Subscriber("goal_posts_relative", PoseWithCertaintyArray, D.blackboard.world_model.goalposts_callback)
     rospy.Subscriber("gamestate", GameState, D.blackboard.gamestate.gamestate_callback)
     rospy.Subscriber("team_data", TeamData, D.blackboard.team_data.team_data_callback)
-    rospy.Subscriber("pose_with_covariance", PoseWithCovarianceStamped, D.blackboard.world_model.position_callback)
+    rospy.Subscriber("pose_with_covariance", PoseWithCovarianceStamped, D.blackboard.world_model.pose_callback)
     rospy.Subscriber("robot_state", RobotControlState, D.blackboard.blackboard.robot_state_callback)
     rospy.Subscriber("move_base/feedback", MoveBaseActionFeedback, D.blackboard.pathfinding.feedback_callback)
 

--- a/bitbots_body_behavior/src/bitbots_body_behavior/body_behavior.py
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/body_behavior.py
@@ -44,7 +44,7 @@ if __name__ == "__main__":
     rospy.Subscriber("goal_posts_relative", PoseWithCertaintyArray, D.blackboard.world_model.goalposts_callback)
     rospy.Subscriber("gamestate", GameState, D.blackboard.gamestate.gamestate_callback)
     rospy.Subscriber("team_data", TeamData, D.blackboard.team_data.team_data_callback)
-    rospy.Subscriber("amcl_pose", PoseWithCovarianceStamped, D.blackboard.world_model.position_callback)
+    rospy.Subscriber("pose_with_covariance", PoseWithCovarianceStamped, D.blackboard.world_model.position_callback)
     rospy.Subscriber("robot_state", RobotControlState, D.blackboard.blackboard.robot_state_callback)
     rospy.Subscriber("move_base/feedback", MoveBaseActionFeedback, D.blackboard.pathfinding.feedback_callback)
 

--- a/bitbots_body_behavior/src/bitbots_body_behavior/decisions/localization.py
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/decisions/localization.py
@@ -14,7 +14,7 @@ class Localization(AbstractDecisionElement):
         :param reevaluate:
         :return:
         """
-        if self.use_localization and self.blackboard.world_model.localization_precision_in_threshold:
+        if self.use_localization and self.blackboard.world_model.localization_precision_in_threshold():
             return 'YES'
         return 'NO'
 

--- a/bitbots_body_behavior/src/bitbots_body_behavior/decisions/localization.py
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/decisions/localization.py
@@ -14,8 +14,9 @@ class Localization(AbstractDecisionElement):
         :param reevaluate:
         :return:
         """
-        #TODO replace this with a dynamic decision based on how sure the robot is about its localization
-        return 'YES' if self.use_localization else 'NO'
+        if self.use_localization and self.blackboard.world_model.localization_precision_in_threshold:
+            return 'YES'
+        return 'NO'
 
     def get_reevaluate(self):
         return False


### PR DESCRIPTION
## Proposed changes
Create a localization precision measurement, which allows the BodyBehavior to decide dynamically whether to use the Localization or not.

## Related issues
Issue #72 requests this feature. After merging this, we will need to find good values for the thresholds before closing it.

## Necessary checks
- [x] Update package version
- [x] Run `catkin build`
- [x] Write documentation
- [x] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

