### PR TITLE
Ball tracking

### DIFF
--- a/bitbots_blackboard/package.xml
+++ b/bitbots_blackboard/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
     <name>bitbots_blackboard</name>
-    <version>1.2.1</version>
+    <version>1.3.0</version>
     <description>The bitbots_blackboard is used to share information
         between the different classes in the behaviour. It consists
         of several capsules each for there own purpose. For example

--- a/bitbots_body_behavior/config/body_behavior.yaml
+++ b/bitbots_body_behavior/config/body_behavior.yaml
@@ -35,7 +35,7 @@ behavior:
 
     # When the ball has not been seen for `ball_lost_time` seconds,
     # it is considered lost and will be searched
-    ball_lost_time: 5
+    ball_lost_time: 15
 
     # The distance we try to keep from the ball when preparing a kick
     ball_approach_distance: 0.25


### PR DESCRIPTION
## Proposed changes
Track the ball in the odom frame or in the map frame depending on the precision of the odometry.
Solves #33. Waits for #72 .
The ball should be saved in the map- as well as the odom-frame, so we can decide which to use based on the current state of the localization.

## Necessary checks
- [x] Update package version
- [x] Run `catkin build`
- [x] Write documentation
- [x] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

