### PR TITLE
Fix a race condition in aligned to goal

### DIFF
--- a/bitbots_body_behavior/package.xml
+++ b/bitbots_body_behavior/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bitbots_body_behavior</name>
-  <version>1.3.0</version>
+  <version>1.3.1</version>
   <description>The bitbots_body_behavior package determines the
         behavior of the robot including strategy decisions and
         kick or walk actions. The node controls the walking indirecty via

--- a/bitbots_body_behavior/src/bitbots_body_behavior/decisions/aligned_to_goal.py
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/decisions/aligned_to_goal.py
@@ -14,15 +14,16 @@ class AlignedToGoal(AbstractDecisionElement):
         determined threshold by comparing the current orientation angle of the robot in the map with the one from the
         move_base goal.
         """
-        if self.blackboard.pathfinding.get_current_pose() is None:
+        current_pose = self.blackboard.pathfinding.get_current_pose()
+        if current_pose is None:
             # When move_base did not received a goal yet, no current position on the map is known.
             # In this case it is not know if the robot is aligned correctly to, e.g., the goal and therefore the robot
             # should not be allowed to kick the ball.
             return 'NO'
-        current_orientation = self.blackboard.pathfinding.get_current_pose().pose.orientation
+        current_orientation = current_pose.pose.orientation
         current_orientation = euler_from_quaternion([current_orientation.x, current_orientation.y,
                                                      current_orientation.z, current_orientation.w])
-        goal_orientation = self.blackboard.pathfinding.get_goal().pose.orientation
+        goal_orientation = current_pose.pose.orientation
         goal_orientation = euler_from_quaternion([goal_orientation.x, goal_orientation.y, goal_orientation.z,
                                                   goal_orientation.w])
         if math.degrees(abs(current_orientation[2] - goal_orientation[2])) < self.orientation_threshold:


### PR DESCRIPTION
## Proposed changes
I got a NoneType error while testing because the value of a function was re-requested after a None-check. Now, we use the same value for the test as well as the computations

## Necessary checks
- [x] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [ ] Put the PR on our Project board

