### PR TITLE
Fix movement of ball/goal relative to robot

### DIFF
--- a/bitbots_blackboard/package.xml
+++ b/bitbots_blackboard/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
     <name>bitbots_blackboard</name>
-    <version>1.3.0</version>
+    <version>1.3.1</version>
     <description>The bitbots_blackboard is used to share information
         between the different classes in the behaviour. It consists
         of several capsules each for there own purpose. For example

--- a/bitbots_blackboard/src/bitbots_blackboard/capsules/world_model_capsule.py
+++ b/bitbots_blackboard/src/bitbots_blackboard/capsules/world_model_capsule.py
@@ -85,19 +85,13 @@ class WorldModelCapsule:
             ball = self.ball_map
         else:
             ball = self.ball_odom
+        ball.header.stamp = rospy.Time(0)
         try:
             ball_bfp = self.tf_buffer.transform(ball, 'base_footprint', timeout=rospy.Duration(0.2)).point
         except (tf2.ExtrapolationException) as e:
             rospy.logwarn(e)
-            try:
-                # retrying with latest time stamp available because the time stamp of the ball_odom.header
-                # seems to be too young and an extrapolation would be required.
-                ball.header.stamp = rospy.Time(0)
-                ball_bfp = self.tf_buffer.transform(ball, 'base_footprint', timeout=rospy.Duration(0.2)).point
-            except (tf2.ExtrapolationException) as e:
-                rospy.logwarn(e)
-                rospy.logerr('Severe transformation problem concerning the ball!')
-                return None
+            rospy.logerr('Severe transformation problem concerning the ball!')
+            return None
         return ball_bfp.x, ball_bfp.y
 
     def get_ball_distance(self):
@@ -187,22 +181,15 @@ class WorldModelCapsule:
         """
         left = PointStamped(self.goal_odom.header, self.goal_odom.left_post)
         right = PointStamped(self.goal_odom.header, self.goal_odom.right_post)
+        left.header.stamp = rospy.Time(0)
+        right.header.stamp = rospy.Time(0)
         try:
             left_bfp = self.tf_buffer.transform(left, 'base_footprint', timeout=rospy.Duration(0.2)).point
             right_bfp = self.tf_buffer.transform(right, 'base_footprint', timeout=rospy.Duration(0.2)).point
         except (tf2.ExtrapolationException) as e:
             rospy.logwarn(e)
-            try:
-                # retrying with latest time stamp available because the time stamp of the goal_odom.header
-                # seems to be too young and an extrapolation would be required.
-                left.header.stamp = rospy.Time(0)
-                right.header.stamp = rospy.Time(0)
-                left_bfp = self.tf_buffer.transform(left, 'base_footprint', timeout=rospy.Duration(0.2)).point
-                right_bfp = self.tf_buffer.transform(right, 'base_footprint', timeout=rospy.Duration(0.2)).point
-            except (tf2.ExtrapolationException) as e:
-                rospy.logwarn(e)
-                rospy.logerr('Severe transformation problem concerning the goal!')
-                return None
+            rospy.logerr('Severe transformation problem concerning the goal!')
+            return None
 
         return (left_bfp.x + right_bfp.x / 2.0), \
                (left_bfp.y + right_bfp.y / 2.0)


### PR DESCRIPTION
## Proposed changes
This fixes some problems related to transforms of ball and goal positions. The fix is that the current timestamp should be used to transform the object in map space back to the base footprint instead of the timestamp where the object was observed.

## Related issues
This closes #99.

## Necessary checks
- [x] Update package version
- [x] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

