### PR TITLE
Fix launch file for behavior test

### DIFF
--- a/bitbots_body_behavior/launch/rviz_behavior_test.launch
+++ b/bitbots_body_behavior/launch/rviz_behavior_test.launch
@@ -5,17 +5,17 @@
     </include>
 
     <rosparam file="$(find bitbots_quintic_walk)/config/walking_wolfgang_robot.yaml" command="load"/>
+    <node name="motor_goals_viz_helper" pkg="bitbots_bringup" type="motor_goals_viz_helper.py"/>
     <node name="walking" pkg="bitbots_quintic_walk" type="WalkNode"  output="screen"/>
     <include file="$(find bitbots_move_base)/launch/pathfinding_move_base.launch" />
 
     <include file="$(find bitbots_animation_server)/launch/animation.launch" />
     <include file="$(find bitbots_hcm)/launch/hcm.launch">
-        <arg name="sim" value="true"/>
+        <arg name="viz" value="true"/>
     </include>
 
     <include file="$(find humanoid_league_interactive_marker)/launch/interactive_marker.launch" />
 
-    <node name="motor_goals_viz_helper" pkg="bitbots_bringup" type="motor_goals_viz_helper.py"/>
     <include file="$(find bitbots_dynamic_kick)/launch/dynamic_kick.launch" />
 
     <node name="show_world_model_objects" pkg="bitbots_body_behavior" type="show_world_model_objects.py"

--- a/bitbots_body_behavior/package.xml
+++ b/bitbots_body_behavior/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bitbots_body_behavior</name>
-  <version>1.3.2</version>
+  <version>1.3.3</version>
   <description>The bitbots_body_behavior package determines the
         behavior of the robot including strategy decisions and
         kick or walk actions. The node controls the walking indirecty via


### PR DESCRIPTION
## Proposed changes
This fixes the launch file for the behavior test to use the new `viz` parameter for the hcm launch file. The motor goal viz helper is moved up to be launched before the hcm.

## Necessary checks
- [x] Update package version
- [x] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] ~Test on the robot~
- [x] Put the PR on our Project board

