### PR TITLE
Param restructure

### DIFF
--- a/bitbots_blackboard/package.xml
+++ b/bitbots_blackboard/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
     <name>bitbots_blackboard</name>
-    <version>1.5.1</version>
+    <version>1.5.2</version>
     <description>The bitbots_blackboard is used to share information
         between the different classes in the behaviour. It consists
         of several capsules each for there own purpose. For example

--- a/bitbots_blackboard/src/bitbots_blackboard/blackboard.py
+++ b/bitbots_blackboard/src/bitbots_blackboard/blackboard.py
@@ -12,11 +12,6 @@ from bitbots_blackboard.capsules.world_model_capsule import WorldModelCapsule
 
 class BodyBlackboard:
     def __init__(self):
-        # TODO this will not stay here, don't worry
-        # it is just that I don't know where this will be placed later
-        self.field_width = 6
-        self.field_length = 9
-        self.goal_width = 2.6
 
         self.config = rospy.get_param("behavior/body")
         self.blackboard = BlackboardCapsule()
@@ -24,7 +19,7 @@ class BodyBlackboard:
         self.animation = AnimationCapsule()
         self.kick = KickCapsule(self)
         self.pathfinding = PathfindingCapsule()
-        self.world_model = WorldModelCapsule(self.config, self.field_length, self.field_width, self.goal_width)
+        self.world_model = WorldModelCapsule()
         self.team_data = TeamDataCapsule()
 
 
@@ -32,6 +27,6 @@ class HeadBlackboard:
     def __init__(self):
         self.config = rospy.get_param("behavior/head")
         self.head_capsule = HeadCapsule(self)
-        self.world_model = WorldModelCapsule(self.config, 6, 9, 2.6)  # TODO move this to a good place
+        self.world_model = WorldModelCapsule()
         rospy.wait_for_service('/bio_ik/get_bio_ik')
         self.bio_ik = rospy.ServiceProxy('/bio_ik/get_bio_ik', GetIK)

--- a/bitbots_blackboard/src/bitbots_blackboard/capsules/pathfinding_capsule.py
+++ b/bitbots_blackboard/src/bitbots_blackboard/capsules/pathfinding_capsule.py
@@ -12,8 +12,8 @@ class PathfindingCapsule:
         # Thresholds to determine whether the transmitted goal is a new one
         self.tf_buffer = tf2_ros.Buffer(cache_time=rospy.Duration(2))
         self.tf_listener = tf2_ros.TransformListener(self.tf_buffer)
-        self.position_threshold = 0.3
-        self.orientation_threshold = 10
+        self.position_threshold = rospy.get_param('/behavior/body/pathfinding_position_threshold')
+        self.orientation_threshold = rospy.get_param('/behavior/body/pathfinding_orientation_threshold')
         self.pathfinding_pub = None  # type: rospy.Publisher
         self.pathfinding_cancel_pub = None  # type: rospy.Publisher
         self.goal = None  # type: PoseStamped

--- a/bitbots_body_behavior/config/body_behavior.yaml
+++ b/bitbots_body_behavior/config/body_behavior.yaml
@@ -111,4 +111,14 @@ behavior:
     # Duration for which the robot pauses between reorientation runs.
     reorientation_pause_duration: 30
 
+    # minimal difference between the current and the last movebase goal to actually send a new goal.
+    pathfinding_position_threshold: 0.3
+    pathfinding_orientation_threshold: 10
+
+
 role: "offense"
+
+# Field measurements in meters
+field_width: 6
+field_length: 9
+goal_width: 2.6

--- a/bitbots_body_behavior/package.xml
+++ b/bitbots_body_behavior/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bitbots_body_behavior</name>
-  <version>1.6.0</version>
+  <version>1.6.1</version>
   <description>The bitbots_body_behavior package determines the
         behavior of the robot including strategy decisions and
         kick or walk actions. The node controls the walking indirectly via


### PR DESCRIPTION
## Proposed changes
Restructures the params and moves field size definitions into the config yaml.

## Related issues
This solves #12 in a more convenient way.

## Necessary checks
- [x] Update package version
- [x] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

