### PR TITLE
New decision deciding whether robot is aligned to goal

### DIFF
--- a/bitbots_body_behavior/config/body_behavior.yaml
+++ b/bitbots_body_behavior/config/body_behavior.yaml
@@ -111,6 +111,9 @@ behavior:
     pathfinding_position_threshold: 0.3
     pathfinding_orientation_threshold: 10
 
+    # don't aim closer to goalpost than this
+    goalpost_safety_distance: 0.1
+
 
 role: "offense"
 

--- a/bitbots_body_behavior/src/bitbots_body_behavior/decisions/aligned_to_goal.py
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/decisions/aligned_to_goal.py
@@ -1,11 +1,44 @@
 from dynamic_stack_decider.abstract_decision_element import AbstractDecisionElement
 from tf.transformations import euler_from_quaternion
 import math
+import rospy
 
 
 class AlignedToGoal(AbstractDecisionElement):
     def __init__(self, blackboard, dsd, parameters=None):
         super(AlignedToGoal, self).__init__(blackboard, dsd, parameters)
+        self.goalpost_safety_distance = self.blackboard.config['goalpost_safety_distance']
+        self.field_length = rospy.get_param("field_length")
+        self.goal_width = rospy.get_param("goal_width")
+
+    def perform(self, reevaluate=False):
+        """
+        It is determined if the robot is correctly aligned to kick the ball into the goal.
+        """
+        current_pose = self.blackboard.world_model.get_current_position()
+        current_ball = self.blackboard.world_model.get_ball_position_xy()
+        if current_pose is None or current_ball is None:
+            return 'NO'
+
+        # calculate the distance of the intersection of a line from the robot throu the ball and the goal line.
+        dist = abs(
+            current_pose[1] +
+            (current_pose[1] - current_ball[1]) *
+            ((- current_pose[0] + self.field_length / 2) / (current_pose[0] - current_ball[0])))
+
+        self.publish_debug_data("projected_distance_to_goal_center", dist)
+        if dist < (self.goal_width / 2) - self.goalpost_safety_distance:
+            return 'YES'
+        else:
+            return 'NO'
+
+    def get_reevaluate(self):
+        return True
+
+
+class AlignedToMoveBaseGoal(AbstractDecisionElement):
+    def __init__(self, blackboard, dsd, parameters=None):
+        super(AlignedToMoveBaseGoal, self).__init__(blackboard, dsd, parameters)
         self.orientation_threshold = self.blackboard.config['goal_alignment_orientation_threshold']  # [deg]
 
     def perform(self, reevaluate=False):
@@ -34,3 +67,4 @@ class AlignedToGoal(AbstractDecisionElement):
 
     def get_reevaluate(self):
         return True
+

--- a/bitbots_body_behavior/src/bitbots_body_behavior/decisions/aligned_to_goal.py
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/decisions/aligned_to_goal.py
@@ -20,7 +20,7 @@ class AlignedToGoal(AbstractDecisionElement):
         if current_pose is None or current_ball is None:
             return 'NO'
 
-        # calculate the distance of the intersection of a line from the robot throu the ball and the goal line.
+        # calculate the distance of the intersection of a line from the robot through the ball and the goal line.
         dist = abs(
             current_pose[1] +
             (current_pose[1] - current_ball[1]) *
@@ -67,4 +67,3 @@ class AlignedToMoveBaseGoal(AbstractDecisionElement):
 
     def get_reevaluate(self):
         return True
-

--- a/bitbots_body_behavior/src/bitbots_body_behavior/main.dsd
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/main.dsd
@@ -7,7 +7,7 @@ $AlignedToGoal
     NO -->  @GoToBall + target:map_goal
 
 #GoAndKickBallDetectionGoal
-$AlignedToGoal
+$AlignedToMoveBaseGoal
     YES --> $BallKickArea
         LEFT --> @Stop, @KickBallDynamic
         RIGHT --> @Stop, @KickBallDynamic


### PR DESCRIPTION
## Proposed changes
Using the new aligned to goal decision estimates whether a kick would end up in the goal or not. This is only used when a localization (and thereby map goal) is available

## Necessary checks
- [ ] Update package version
- [x] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Put the PR on our Project board

