### PR TITLE
Merge ball kick areas

### DIFF
--- a/bitbots_body_behavior/config/body_behavior.yaml
+++ b/bitbots_body_behavior/config/body_behavior.yaml
@@ -57,21 +57,13 @@ behavior:
     # the duration after which a ball_twist is considered irrelevant.
     ball_twist_lost_time: 2
 
-    # An area in which the ball can be kicked with the right foot
+    # An area in which the ball can be kicked
     # defined by min/max x/y values in meters which represent ball positions relative to base_footprint
     # http://www.ros.org/reps/rep-0103.html#axis-orientation
-    right_kick_min_x: 0
-    right_kick_min_y: -0.15
-    right_kick_max_x: 0.3
-    right_kick_max_y: 0
-
-    # An area in which the ball can be kicked with the left foot
-    # defined by min/max x/y values in meters which represent ball positions relative to base_footprint
-    # http://www.ros.org/reps/rep-0103.html#axis-orientation
-    left_kick_min_x: 0
-    left_kick_min_y: 0
-    left_kick_max_x: 0.3
-    left_kick_max_y: 0.15
+    kick_min_x: 0
+    kick_min_y: -0.20
+    kick_max_x: 0.35
+    kick_max_y: 0.20
 
     # defines the radius around the goal (in form of a box)
     # in this area, the goalie will react to the ball.

--- a/bitbots_body_behavior/scripts/show_world_model_objects.py
+++ b/bitbots_body_behavior/scripts/show_world_model_objects.py
@@ -79,31 +79,18 @@ class ShowWorldModelObjects:
         self.marker_goal_second_post.lifetime = rospy.Duration(self.lifetime_goal)
 
         # init ball kick area markers
-        self.marker_kick_area_right = Marker()
-        self.marker_kick_area_right.id = 3
-        self.marker_kick_area_right.type = Marker.LINE_STRIP
-        self.marker_kick_area_right.scale.x = 0.01
-        self.kick_area_right_color = ColorRGBA()
-        self.kick_area_right_color.a = 0.5
-        self.kick_area_right_color.r = 0.8
-        self.kick_area_right_color.g = 0.8
-        self.kick_area_right_color.b = 0.8
-        self.marker_kick_area_right.color = self.kick_area_right_color
-        self.marker_kick_area_right.lifetime = rospy.Duration(self.lifetime_ball_kick_area)
-        self.marker_kick_area_right.pose.orientation.w = 1.0
-
-        self.marker_kick_area_left = Marker()
-        self.marker_kick_area_left.id = 4
-        self.marker_kick_area_left.type = Marker.LINE_STRIP
-        self.marker_kick_area_left.scale.x = 0.01
-        self.kick_area_left_color = ColorRGBA()
-        self.kick_area_left_color.a = 0.5
-        self.kick_area_left_color.r = 0.8
-        self.kick_area_left_color.g = 0.8
-        self.kick_area_left_color.b = 0.8
-        self.marker_kick_area_left.color = self.kick_area_left_color
-        self.marker_kick_area_left.lifetime = rospy.Duration(self.lifetime_ball_kick_area)
-        self.marker_kick_area_left.pose.orientation.w = 1.0
+        self.marker_kick_area = Marker()
+        self.marker_kick_area.id = 3
+        self.marker_kick_area.type = Marker.LINE_STRIP
+        self.marker_kick_area.scale.x = 0.01
+        self.kick_area_color = ColorRGBA()
+        self.kick_area_color.a = 0.5
+        self.kick_area_color.r = 0.8
+        self.kick_area_color.g = 0.8
+        self.kick_area_color.b = 0.8
+        self.marker_kick_area.color = self.kick_area_color
+        self.marker_kick_area.lifetime = rospy.Duration(self.lifetime_ball_kick_area)
+        self.marker_kick_area.pose.orientation.w = 1.0
 
         # init subscribers
         rospy.Subscriber("debug/viz_ball", PointStamped, self.ball_cb, queue_size=10)
@@ -111,16 +98,11 @@ class ShowWorldModelObjects:
         rospy.Subscriber("debug/viz_ball_kick_area", String, self.kick_area_cb, queue_size=10)
 
         # load kick area info
-        kick_right_max_x = rospy.get_param('behavior/body/right_kick_max_x')
-        kick_right_max_y = rospy.get_param('behavior/body/right_kick_max_y')
-        kick_right_min_x = rospy.get_param('behavior/body/right_kick_min_x')
-        kick_right_min_y = rospy.get_param('behavior/body/right_kick_min_y')
-        kick_left_max_x = rospy.get_param('behavior/body/left_kick_max_x')
-        kick_left_max_y = rospy.get_param('behavior/body/left_kick_max_y')
-        kick_left_min_x = rospy.get_param('behavior/body/left_kick_min_x')
-        kick_left_min_y = rospy.get_param('behavior/body/left_kick_min_y')
-        self.kick_area_info = [[kick_right_max_x, kick_right_max_y, kick_right_min_x, kick_right_min_y],
-                               [kick_left_max_x, kick_left_max_y, kick_left_min_x, kick_left_min_y]]
+        kick_max_x = rospy.get_param('behavior/body/kick_max_x')
+        kick_max_y = rospy.get_param('behavior/body/kick_max_y')
+        kick_min_x = rospy.get_param('behavior/body/kick_min_x')
+        kick_min_y = rospy.get_param('behavior/body/kick_min_y')
+        self.kick_area_info = [kick_max_x, kick_max_y, kick_min_x, kick_min_y]
 
         # init tf listener for ball_kick_area_viz
         self.tfBuffer = tf2_ros.Buffer()
@@ -147,40 +129,30 @@ class ShowWorldModelObjects:
                 continue
 
             # set stamp and frame_id
-            self.marker_kick_area_right.header.stamp = rospy.Time.now()
-            self.marker_kick_area_right.header.frame_id = self.base_footprint_frame
-            self.marker_kick_area_left.header.stamp = rospy.Time.now()
-            self.marker_kick_area_left.header.frame_id = self.base_footprint_frame
+            self.marker_kick_area.header.stamp = rospy.Time.now()
+            self.marker_kick_area.header.frame_id = self.base_footprint_frame
             # set corners of the two square markers
-            kick_areas = []
-            for i in range(2):
-                point1 = Point()
-                point1.x = current_base_link_pose.transform.translation.x + self.kick_area_info[i][0]
-                point1.y = current_base_link_pose.transform.translation.y + self.kick_area_info[i][1]
-                point2 = Point()
-                point2.x = current_base_link_pose.transform.translation.x + self.kick_area_info[i][0]
-                point2.y = current_base_link_pose.transform.translation.y + self.kick_area_info[i][3]
-                point3 = Point()
-                point3.x = current_base_link_pose.transform.translation.x + self.kick_area_info[i][2]
-                point3.y = current_base_link_pose.transform.translation.y + self.kick_area_info[i][3]
-                point4 = Point()
-                point4.x = current_base_link_pose.transform.translation.x + self.kick_area_info[i][2]
-                point4.y = current_base_link_pose.transform.translation.y + self.kick_area_info[i][1]
-                kick_area = [point1, point2, point3, point4, point1]
-                kick_areas.append(kick_area)
-            self.marker_kick_area_right.points = kick_areas[0]
-            self.marker_kick_area_left.points = kick_areas[1]
+            point1 = Point()
+            point1.x = current_base_link_pose.transform.translation.x + self.kick_area_info[0]
+            point1.y = current_base_link_pose.transform.translation.y + self.kick_area_info[1]
+            point2 = Point()
+            point2.x = current_base_link_pose.transform.translation.x + self.kick_area_info[0]
+            point2.y = current_base_link_pose.transform.translation.y + self.kick_area_info[3]
+            point3 = Point()
+            point3.x = current_base_link_pose.transform.translation.x + self.kick_area_info[2]
+            point3.y = current_base_link_pose.transform.translation.y + self.kick_area_info[3]
+            point4 = Point()
+            point4.x = current_base_link_pose.transform.translation.x + self.kick_area_info[2]
+            point4.y = current_base_link_pose.transform.translation.y + self.kick_area_info[1]
+            kick_area = [point1, point2, point3, point4, point1]
+            self.marker_kick_area.points = kick_area
 
             # set color back to grey
             if abs(self.last_received_kick_info - rospy.Time.now()) > rospy.Duration(1):
-                self.marker_kick_area_right.color.r = 0.8
-                self.marker_kick_area_right.color.g = 0.8
-                self.marker_kick_area_right.color.b = 0.8
-                self.marker_kick_area_left.color.r = 0.8
-                self.marker_kick_area_left.color.g = 0.8
-                self.marker_kick_area_left.color.b = 0.8
-            self.marker_publisher.publish(self.marker_kick_area_right)
-            self.marker_publisher.publish(self.marker_kick_area_left)
+                self.marker_kick_area.color.r = 0.8
+                self.marker_kick_area.color.g = 0.8
+                self.marker_kick_area.color.b = 0.8
+            self.marker_publisher.publish(self.marker_kick_area)
 
     def ball_cb(self, msg):
         self.marker_ball.header = msg.header
@@ -203,32 +175,16 @@ class ShowWorldModelObjects:
             self.marker_publisher.publish(self.marker_goal_second_post)
 
     def kick_area_cb(self, msg):
-        # set the marker for the right ball_kick_area to green and the left one to red as the behavior decided the ball
-        # is within this area
-        if msg.data == 'RIGHT':
-            self.marker_kick_area_right.color.r = 0.0
-            self.marker_kick_area_right.color.g = 1.0
-            self.marker_kick_area_right.color.b = 0.0
-            self.marker_kick_area_left.color.r = 1.0
-            self.marker_kick_area_left.color.g = 0.0
-            self.marker_kick_area_left.color.b = 0.0
-        # set the marker for the left ball_kick_area to green and the right one to red as the behavior decided the ball
-        # is within this area
-        elif msg.data == 'LEFT':
-            self.marker_kick_area_left.color.r = 0.0
-            self.marker_kick_area_left.color.g = 1.0
-            self.marker_kick_area_right.color.b = 0.0
-            self.marker_kick_area_right.color.r = 1.0
-            self.marker_kick_area_right.color.g = 0.0
-            self.marker_kick_area_left.color.b = 0.0
-        # set the color of both markers to red as the behavior decided the ball is not within one of the areas
+        # set the marker for the ball_kick_area to green as the behavior decided the ball is within this area
+        if msg.data == 'NEAR':
+            self.marker_kick_area.color.r = 0.0
+            self.marker_kick_area.color.g = 1.0
+            self.marker_kick_area.color.b = 0.0
+        # set the color of the marker to red as the behavior decided the ball is not within the area
         else:
-            self.marker_kick_area_right.color.r = 1.0
-            self.marker_kick_area_right.color.g = 0.0
-            self.marker_kick_area_right.color.b = 0.0
-            self.marker_kick_area_left.color.r = 1.0
-            self.marker_kick_area_left.color.g = 0.0
-            self.marker_kick_area_left.color.b = 0.0
+            self.marker_kick_area.color.r = 1.0
+            self.marker_kick_area.color.g = 0.0
+            self.marker_kick_area.color.b = 0.0
         self.last_received_kick_info = rospy.Time.now()
 
 

--- a/bitbots_body_behavior/src/bitbots_body_behavior/decisions/ball_kick_area.py
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/decisions/ball_kick_area.py
@@ -8,14 +8,10 @@ class BallKickArea(AbstractDecisionElement):
     def __init__(self, blackboard, dsd, parameters=None):
         super(BallKickArea, self).__init__(blackboard, dsd, parameters)
         self.ball_close_distance = self.blackboard.config['ball_close_distance']
-        self.right_kick_min_x = self.blackboard.config['right_kick_min_x']
-        self.right_kick_min_y = self.blackboard.config['right_kick_min_y']
-        self.right_kick_max_x = self.blackboard.config['right_kick_max_x']
-        self.right_kick_max_y = self.blackboard.config['right_kick_max_y']
-        self.left_kick_min_x = self.blackboard.config['left_kick_min_x']
-        self.left_kick_min_y = self.blackboard.config['left_kick_min_y']
-        self.left_kick_max_x = self.blackboard.config['left_kick_max_x']
-        self.left_kick_max_y = self.blackboard.config['left_kick_max_y']
+        self.kick_min_x = self.blackboard.config['kick_min_x']
+        self.kick_min_y = self.blackboard.config['kick_min_y']
+        self.kick_max_x = self.blackboard.config['kick_max_x']
+        self.kick_max_y = self.blackboard.config['kick_max_y']
         self.viz_publisher = rospy.Publisher('debug/viz_ball_kick_area', String, queue_size=1)
 
     def perform(self, reevaluate=False):
@@ -29,14 +25,10 @@ class BallKickArea(AbstractDecisionElement):
 
         self.publish_debug_data("ball_position", {"u": ball_position[0], "v": ball_position[1]})
 
-        if self.right_kick_min_x <= ball_position[0] <= self.right_kick_max_x and \
-           self.right_kick_min_y <= ball_position[1] <= self.right_kick_max_y:
-            self.viz_publisher.publish('RIGHT')
-            return 'RIGHT'
-        if self.left_kick_min_x <= ball_position[0] <= self.left_kick_max_x and \
-           self.left_kick_min_y <= ball_position[1] <= self.left_kick_max_y:
-            self.viz_publisher.publish('LEFT')
-            return 'LEFT'
+        if self.kick_min_x <= ball_position[0] <= self.kick_max_x and \
+           self.kick_min_y <= ball_position[1] <= self.kick_max_y:
+            self.viz_publisher.publish('NEAR')
+            return 'NEAR'
         # TODO: areas for TURN RIGHT/LEFT/AROUND might be useful.
         self.viz_publisher.publish('FAR')
         return 'FAR'

--- a/bitbots_body_behavior/src/bitbots_body_behavior/main.dsd
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/main.dsd
@@ -3,8 +3,7 @@ $AvoidBall
     NO --> $BallClose + distance:%behavior/body/ball_reaproach_dist
         YES --> $AlignedToGoal
             YES --> $BallKickArea
-                LEFT --> @Stop, @LookAtBall, @StandAndWait + duration:1, @LookForward, @KickBallDynamic
-                RIGHT --> @Stop, @LookAtBall, @StandAndWait + duration:1, @LookForward, @KickBallDynamic
+                NEAR --> @Stop, @LookAtBall, @StandAndWait + duration:1, @LookForward, @KickBallDynamic
                 FAR --> @LookAtBall, @GoToBall + target:map_goal
             NO --> @LookAtBall, @GoToBall + target:map_goal
         NO --> @LookAtFieldFeatures, @GoToBall + target:map_goal + blocking:false + distance:%behavior/body/ball_far_approach_dist, @AvoidBallActive

--- a/bitbots_body_behavior/src/bitbots_body_behavior/main.dsd
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/main.dsd
@@ -14,15 +14,13 @@ $AvoidBall
 #GoAndKickBallDetectionGoal
 $AlignedToMoveBaseGoal
     YES --> $BallKickArea
-        LEFT --> @Stop, @LookForward, @KickBallDynamic
-        RIGHT --> @Stop, @LookForward, @KickBallDynamic
+        NEAR --> @Stop, @LookForward, @KickBallDynamic
         FAR --> @GoToBall + target:detection_goal
     NO --> @GoToBall + target:detection_goal
 
 #GoAndKickBallAway
 $BallKickArea
-    LEFT --> @Stop, @LookForward, @KickBallDynamic
-    RIGHT --> @Stop, @LookForward, @KickBallDynamic
+    NEAR --> @Stop, @LookForward, @KickBallDynamic
     FAR --> @GoToBall + target:close
 
 #NoLocalizationPlayerBehavior
@@ -124,8 +122,7 @@ $LocalizationAvailable
 #PenaltyBehavior
 $BallSeen
     YES --> $BallKickArea
-        RIGHT --> @Stop, @LookForward, @KickBallDynamic + type:penalty
-        LEFT --> @Stop, @LookForward, @KickBallDynamic + type:penalty
+        NEAR --> @Stop, @LookForward, @KickBallDynamic + type:penalty
         FAR --> $GoalSeen
             YES --> @GoToBall + target:detection_goal
             NO --> @GoToBall + target:close


### PR DESCRIPTION
## Proposed changes
This pull request merges the kick areas for left and right so that the behavior does not struggle between the two. The dynamic kick takes the ball direction directly, so the resulting action is the same.

## Related issues
Closes #145.

## Necessary checks
- [ ] Update package version
- [x] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

