### PR TITLE
body_behavior: Wait before positioning ready

### DIFF
--- a/bitbots_body_behavior/config/body_behavior.yaml
+++ b/bitbots_body_behavior/config/body_behavior.yaml
@@ -33,6 +33,9 @@ behavior:
       # position number 0 = center, 1 = left, 2 = right
       pos_number: 0
 
+    # Time to wait in ready state before moving to role position to give the localization time to converge.
+    ready_wait_time: 4
+
     # When the ball has not been seen for `ball_lost_time` seconds,
     # it is considered lost and will be searched
     ball_lost_time: 15

--- a/bitbots_body_behavior/src/bitbots_body_behavior/main.dsd
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/main.dsd
@@ -44,12 +44,12 @@ $BallSeen
 
 #Positioning
 $LocalizationAvailable
-    YES --> @LookAtFieldFeatures, @AvoidBallActive, @GoToRolePosition
+    YES --> @LookAtFieldFeatures, @StandAndWait + duration:%behavior/body/ready_wait_time, @AvoidBallActive, @GoToRolePosition
     NO --> @GoToRelativePosition + x:2 + y:0 + t:0
 
 #PositioningReady
 $LocalizationAvailable
-    YES --> @LookAtFieldFeatures, @AvoidBallActive, @GoToRolePosition
+    YES --> @LookAtFieldFeatures, @StandAndWait + duration:%behavior/body/ready_wait_time, @AvoidBallActive, @GoToRolePosition
     NO --> @GoToRelativePosition + x:2 + y:0 + t:0, @StandAndWait
 
 #GoalieBehavior


### PR DESCRIPTION
## Proposed changes
After transitioning from the gamestate `init` to `ready`, the robot now waits for 4 (approx. 1 search pattern) seconds before moving to the ready position

## Related issues
Closes bit-bots/bitbots_navigation#113

## Necessary checks
~- [ ] Run `catkin build`~
~- [ ] Write documentation~
~- [ ] Create issues for future work~
- [x] Test on your machine
~- [ ] Test on the robot~
- [x] Put the PR on our Project board

