### PR TITLE
fix go to kickoff position

### DIFF
--- a/bitbots_body_behavior/config/body_behavior.yaml
+++ b/bitbots_body_behavior/config/body_behavior.yaml
@@ -30,6 +30,7 @@ behavior:
       goalie: [-0.95, 0]
       defense: [[-0.5, 0], [-0.45, 0.5], [-0.45, -0.5]]
       offense: [[-0.25, 0], [-0.2, 0.5], [-0.2, -0.5]]
+      kickoff: [[-0.05, 0]]
       # position number 0 = center, 1 = left, 2 = right
       pos_number: 0
 

--- a/bitbots_body_behavior/config/body_behavior.yaml
+++ b/bitbots_body_behavior/config/body_behavior.yaml
@@ -30,7 +30,7 @@ behavior:
       goalie: [-0.95, 0]
       defense: [[-0.5, 0], [-0.45, 0.5], [-0.45, -0.5]]
       offense: [[-0.25, 0], [-0.2, 0.5], [-0.2, -0.5]]
-      kickoff: [-0.05, 0]
+      kickoff: [-0.1, 0]
       # position number 0 = center, 1 = left, 2 = right
       pos_number: 0
 

--- a/bitbots_body_behavior/config/body_behavior.yaml
+++ b/bitbots_body_behavior/config/body_behavior.yaml
@@ -30,7 +30,7 @@ behavior:
       goalie: [-0.95, 0]
       defense: [[-0.5, 0], [-0.45, 0.5], [-0.45, -0.5]]
       offense: [[-0.25, 0], [-0.2, 0.5], [-0.2, -0.5]]
-      kickoff: [[-0.05, 0]]
+      kickoff: [-0.05, 0]
       # position number 0 = center, 1 = left, 2 = right
       pos_number: 0
 

--- a/bitbots_body_behavior/src/bitbots_body_behavior/actions/go_to_role_position.py
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/actions/go_to_role_position.py
@@ -12,6 +12,9 @@ class GoToRolePosition(AbstractActionElement):
         try:
             if self.blackboard.blackboard.duty == 'goalie':
                 generalized_role_position = role_positions[self.blackboard.blackboard.duty]
+            elif self.blackboard.blackboard.duty == 'offense' and role_positions['pos_number'] == 0 and self.blackboard.gamestate.has_kickoff():
+                # handle kick of specifically. Let center offence go near ball
+                generalized_role_position = role_positions['kickoff']
             else:
                 # players other than the goalie have multiple possible positions
                 generalized_role_position = \


### PR DESCRIPTION
## Proposed changes
Lets center offense player got close to the ball when we have kickoff


## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Put the PR on our Project board

