### PR TITLE
Fix goal scored decision in simulation time

### DIFF
--- a/bitbots_blackboard/src/bitbots_blackboard/capsules/game_status_capsule.py
+++ b/bitbots_blackboard/src/bitbots_blackboard/capsules/game_status_capsule.py
@@ -16,7 +16,7 @@ class GameStatusCapsule:
         self.gamestate = GameState()
         self.last_update = 0
         self.unpenalized_time = 0
-        self.last_goal_from_us_time = rospy.Duration(86400)
+        self.last_goal_from_us_time = -10
 
     def is_game_state_equals(self, value):
         assert value in [GameState.GAMESTATE_PLAYING, GameState.GAMESTATE_FINISHED, GameState.GAMESTATE_INITAL,
@@ -50,7 +50,7 @@ class GameStatusCapsule:
         return self.gamestate.rivalScore
 
     def get_seconds_since_own_goal(self):
-        return rospy.Time.now() - self.last_goal_from_us_time
+        return rospy.get_time() - self.last_goal_from_us_time
 
     def get_seconds_remaining(self):
         # Time from the message minus time passed since receiving it
@@ -86,7 +86,7 @@ class GameStatusCapsule:
             self.unpenalized_time = rospy.get_time()
 
         if gs.ownScore > self.gamestate.ownScore:
-            self.last_goal_from_us_time = rospy.Time.now()
+            self.last_goal_from_us_time = rospy.get_time()
 
         self.last_update = rospy.get_time()
         self.gamestate = gs

--- a/bitbots_blackboard/src/bitbots_blackboard/capsules/game_status_capsule.py
+++ b/bitbots_blackboard/src/bitbots_blackboard/capsules/game_status_capsule.py
@@ -16,7 +16,7 @@ class GameStatusCapsule:
         self.gamestate = GameState()
         self.last_update = 0
         self.unpenalized_time = 0
-        self.last_goal_from_us_time = -10
+        self.last_goal_from_us_time = -86400
 
     def is_game_state_equals(self, value):
         assert value in [GameState.GAMESTATE_PLAYING, GameState.GAMESTATE_FINISHED, GameState.GAMESTATE_INITAL,

--- a/bitbots_body_behavior/src/bitbots_body_behavior/decisions/goal_scored.py
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/decisions/goal_scored.py
@@ -14,7 +14,7 @@ class GoalScoreRecently(AbstractDecisionElement):
         :return:
         """
 
-        if self.blackboard.gamestate.get_seconds_since_own_goal().to_sec() < 2:
+        if self.blackboard.gamestate.get_seconds_since_own_goal() < 2:
             return 'YES'
         return 'NO'
 


### PR DESCRIPTION
## Proposed changes
#180 does not work when the ros time is less than one day because ros times may not be negative, which would happen in `rospy.Time.now() - self.last_goal_from_us_time` when the second is at its default value of one day. This fixes the issue.

Please test this again because on my machine at least the cheering animation is interrupted, possibly because it pops itself from the stack. But this also happens on master, so it is probably an issue with my setup.

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

