### PR TITLE
StandAndWait after penalty and in initial

### DIFF
--- a/bitbots_blackboard/src/bitbots_blackboard/blackboard.py
+++ b/bitbots_blackboard/src/bitbots_blackboard/blackboard.py
@@ -31,6 +31,7 @@ class BodyBlackboard:
         self.goalie_falling_right_animation = rospy.get_param("Animations/Goalie/fallRight")
         self.goalie_falling_left_animation = rospy.get_param("Animations/Goalie/fallLeft")
         self.cheering_animation = rospy.get_param("Animations/Misc/cheering")
+        self.init_animation = rospy.get_param("Animations/Misc/init")
 
         self.dynup_action_client = None
 

--- a/bitbots_body_behavior/config/animations.yaml
+++ b/bitbots_body_behavior/config/animations.yaml
@@ -30,3 +30,4 @@ Animations:
 
   Misc:
     cheering: "cheering"
+    init: "init_sim"

--- a/bitbots_body_behavior/src/bitbots_body_behavior/actions/get_walkready.py
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/actions/get_walkready.py
@@ -1,6 +1,8 @@
+import rospy
 from bitbots_hcm.hcm_dsd.actions.play_animation import PlayAnimationDynup
 
 
 class GetWalkready(PlayAnimationDynup):
     def __init__(self, blackboard, dsd, parameters=None):
+        rospy.logerr("dynup body action")
         super(GetWalkready, self).__init__(blackboard, dsd, parameters={'initial': True, 'direction': 'walkready'})

--- a/bitbots_body_behavior/src/bitbots_body_behavior/actions/kick_ball.py
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/actions/kick_ball.py
@@ -60,9 +60,7 @@ class KickBallDynamic(AbstractKickAction):
                 goal = KickGoal()
                 goal.header.stamp = rospy.Time.now()
 
-                # TODO evaluate whether the dynamic kick is good enough to actually use the ball position
                 # currently we use a tested left or right kick
-                ball_u, ball_v = self.blackboard.world_model.get_ball_position_uv()
                 goal.header.frame_id = self.blackboard.world_model.base_footprint_frame  # the ball position is stated in this frame
 
                 if self.penalty_kick:
@@ -72,6 +70,7 @@ class KickBallDynamic(AbstractKickAction):
                     goal.ball_position.z = 0
                     kick_direction = math.radians(25)
                 else:
+                    ball_u, ball_v = self.blackboard.world_model.get_ball_position_uv()
                     goal.kick_speed = 1
                     goal.ball_position.x = ball_u
                     goal.ball_position.y = ball_v

--- a/bitbots_body_behavior/src/bitbots_body_behavior/actions/kick_ball.py
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/actions/kick_ball.py
@@ -53,7 +53,6 @@ class KickBallDynamic(AbstractKickAction):
         self.never_reevaluate = parameters.get('r', False)
 
     def perform(self, reevaluate=False):
-        self.do_not_reevaluate()
 
         if not self.blackboard.kick.is_currently_kicking:
             if not self._goal_sent:

--- a/bitbots_body_behavior/src/bitbots_body_behavior/actions/kick_ball.py
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/actions/kick_ball.py
@@ -50,6 +50,7 @@ class KickBallDynamic(AbstractKickAction):
         self.angular_range = rospy.get_param('behavior/body/kick_cost_angular_range')
         self.max_kick_angle = rospy.get_param('behavior/body/max_kick_angle')
         self.num_kick_angles = rospy.get_param('behavior/body/num_kick_angles')
+        self.never_reevaluate = parameters.get('r', False)
 
     def perform(self, reevaluate=False):
         self.do_not_reevaluate()

--- a/bitbots_body_behavior/src/bitbots_body_behavior/actions/kick_ball.py
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/actions/kick_ball.py
@@ -68,6 +68,7 @@ class KickBallDynamic(AbstractKickAction):
                     goal.ball_position.x = 0.22
                     goal.ball_position.y = 0.0
                     goal.ball_position.z = 0
+                    goal.unstable = True
                     kick_direction = math.radians(25)
                 else:
                     ball_u, ball_v = self.blackboard.world_model.get_ball_position_uv()
@@ -75,6 +76,7 @@ class KickBallDynamic(AbstractKickAction):
                     goal.ball_position.x = ball_u
                     goal.ball_position.y = ball_v
                     goal.ball_position.z = 0
+                    goal.unstable = False
                     kick_directions = sorted(np.linspace(
                         -self.max_kick_angle,
                         self.max_kick_angle,

--- a/bitbots_body_behavior/src/bitbots_body_behavior/actions/kick_ball.py
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/actions/kick_ball.py
@@ -66,13 +66,11 @@ class KickBallDynamic(AbstractKickAction):
 
                 if self.penalty_kick:
                     goal.kick_speed = 6.7
-                    goal.ball_position.x = 0.2
+                    goal.ball_position.x = 0.25
                     goal.ball_position.y = 0.0
                     goal.ball_position.z = 0
                     kick_direction = math.radians(25)
-                    rospy.logerr("foo")
                 else:
-                    rospy.logerr("bar")
                     goal.kick_speed = 1
                     goal.ball_position.x = ball_u
                     goal.ball_position.y = ball_v

--- a/bitbots_body_behavior/src/bitbots_body_behavior/actions/kick_ball.py
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/actions/kick_ball.py
@@ -63,26 +63,31 @@ class KickBallDynamic(AbstractKickAction):
                 # currently we use a tested left or right kick
                 ball_u, ball_v = self.blackboard.world_model.get_ball_position_uv()
                 goal.header.frame_id = self.blackboard.world_model.base_footprint_frame  # the ball position is stated in this frame
-                goal.ball_position.x = ball_u
-                goal.ball_position.y = ball_v
-                goal.ball_position.z = 0
-
-                kick_directions = sorted(np.linspace(
-                    -self.max_kick_angle,
-                    self.max_kick_angle,
-                    num=self.num_kick_angles), key=abs)
-
-                kick_direction = kick_directions[np.argmin([self.blackboard.world_model.get_current_cost_of_kick(
-                    direction=direction,
-                    kick_length=self.kick_length,
-                    angular_range=self.angular_range)
-                    for direction in kick_directions])]
-                goal.kick_direction = Quaternion(*quaternion_from_euler(0, 0, kick_direction))
 
                 if self.penalty_kick:
-                    goal.kick_speed = 3
+                    goal.kick_speed = 6.7
+                    goal.ball_position.x = 0.2
+                    goal.ball_position.y = 0.0
+                    goal.ball_position.z = 0
+                    kick_direction = math.radians(25)
+                    rospy.logerr("foo")
                 else:
+                    rospy.logerr("bar")
                     goal.kick_speed = 1
+                    goal.ball_position.x = ball_u
+                    goal.ball_position.y = ball_v
+                    goal.ball_position.z = 0
+                    kick_directions = sorted(np.linspace(
+                        -self.max_kick_angle,
+                        self.max_kick_angle,
+                        num=self.num_kick_angles), key=abs)
+
+                    kick_direction = kick_directions[np.argmin([self.blackboard.world_model.get_current_cost_of_kick(
+                        direction=direction,
+                        kick_length=self.kick_length,
+                        angular_range=self.angular_range)
+                        for direction in kick_directions])]
+                goal.kick_direction = Quaternion(*quaternion_from_euler(0, 0, kick_direction))
 
                 self.blackboard.kick.kick(goal)
                 self._goal_sent = True

--- a/bitbots_body_behavior/src/bitbots_body_behavior/actions/play_animation.py
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/actions/play_animation.py
@@ -92,3 +92,7 @@ class PlayAnimationCheering(AbstractPlayAnimation):
     def chose_animation(self):
         rospy.loginfo("PLAYING CHEERING ANIMATION")
         return self.blackboard.cheering_animation
+
+class PlayAnimationInit(AbstractPlayAnimation):
+    def chose_animation(self):
+        return self.blackboard.init_animation

--- a/bitbots_body_behavior/src/bitbots_body_behavior/body_behavior.py
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/body_behavior.py
@@ -38,7 +38,7 @@ if __name__ == "__main__":
     D.blackboard.pathfinding.approach_marker_pub = rospy.Publisher("debug/approach_point", Marker, queue_size=10)
 
     D.blackboard.dynup_cancel_pub = rospy.Publisher('dynup/cancel', GoalID, queue_size=1)
-    D.blackboard.hcm_deactivate_pub = rospy.Publisher('hcm_restart', Bool, queue_size=1)
+    D.blackboard.hcm_deactivate_pub = rospy.Publisher('hcm_deactivate', Bool, queue_size=1)
 
     dirname = os.path.dirname(os.path.realpath(__file__))
 

--- a/bitbots_body_behavior/src/bitbots_body_behavior/decisions/is_penalty_shoot_robot.py
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/decisions/is_penalty_shoot_robot.py
@@ -1,0 +1,19 @@
+from dynamic_stack_decider.abstract_decision_element import AbstractDecisionElement
+
+
+class IsPenaltyShootRobot(AbstractDecisionElement):
+    def __init__(self, blackboard, dsd, parameters=None):
+        super().__init__(blackboard, dsd, parameters)
+        self.own_id = self.blackboard.team_data.bot_id
+
+    def perform(self, reevaluate=False):
+        """
+        Determines if the robot is the one that should do something during penalty shoot out
+        """
+        if self.own_id == 1:
+            return "YES"
+        else:
+            return "NO"
+
+    def get_reevaluate(self):
+        return True

--- a/bitbots_body_behavior/src/bitbots_body_behavior/main.dsd
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/main.dsd
@@ -111,7 +111,7 @@ $LocalizationAvailable
 
 #PenaltyBehavior
 $SecondaryStateTeamDecider
-    OUR --> @KickBallDynamic, @LookAtFieldFeatures, @StandAndWait + duration:1
+    OUR --> @KickBallDynamic + r:true, @LookAtFieldFeatures, @StandAndWait + duration:1
     OTHER --> $BallDangerous
         LEFT --> @Stop, @LookAtBall, @PlayAnimationGoalieFallLeft
         RIGHT --> @Stop, @LookAtBall, @PlayAnimationGoalieFallRight

--- a/bitbots_body_behavior/src/bitbots_body_behavior/main.dsd
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/main.dsd
@@ -8,7 +8,10 @@
 @ChangeAction + action:waiting, @LookAtFieldFeatures, @StandAndWait
 
 #GetWalkreadyAndLocalize
-@ChangeAction + action:waiting + r:false, @StandAndWait + duration:1 + r:false, @GetWalkready + r:false, @LookAtFieldFeatures + r:false, @StandAndWait + duration:2 + r:false
+@ChangeAction + action:waiting + r:false, @StandAndWait + duration:1 + r:false, @GetWalkready + r:false, @LookAtFieldFeatures + r:false, @StandAndWait + duration:2 + r:false, @StandAndWait
+
+#GetWalkreadyAndLookAtBall
+@ChangeAction + action:waiting + r:false, @StandAndWait + duration:1 + r:false, @GetWalkready + r:false, @LookAtBall + r:false, @StandAndWait + duration:2 + r:false, @StandAndWait
 
 #GoAndKickBallMapGoal
 $AvoidBall
@@ -110,10 +113,7 @@ $LocalizationAvailable
 
 #PenaltyBehavior
 $SecondaryStateTeamDecider
-    OUR --> $GameStateDecider //in penalty we use the main game states to start the positioning and the kicks
-        READY --> @LookAtBall, @GoToBall + target:map_goal + distance:%behavior/body/ball_far_approach_dist
-        PLAYING --> #GoAndKickBallMapGoal
-        ELSE --> #StandAndLook
+    OUR --> @LookAtBall, @StandAndWait + duration:1.0, @LookForward + r:false, @KickBallDynamic, @LookAtFieldFeatures + r:false, @StandAndWait + duration:1 + r:false
     OTHER --> $BallDangerous
         LEFT --> @Stop, @LookAtBall, @PlayAnimationGoalieFallLeft
         RIGHT --> @Stop, @LookAtBall, @PlayAnimationGoalieFallRight
@@ -145,10 +145,12 @@ $IsPenalized
     YES --> #DoNothing
     JUST_UNPENALIZED --> #GetWalkreadyAndLocalize
     NO --> $GameStateDecider
-        INITIAL --> @ChangeAction + action:waiting + r:false, @StandAndWait + duration:1 + r:false, @GetWalkready + r:false, @LookAtFieldFeatures + r:false, @StandAndWait
+        INITIAL --> @ChangeAction + action:waiting + r:false, @StandAndWait + duration:1 + r:false, @GetWalkready + r:false, @LookAtFieldFeatures + r:false, @StandAndWait + duration:2 + r:false, @StandAndWait
         READY --> #PositioningReady
         SET --> $SecondaryStateDecider
-            PENALTYSHOOT --> #GetWalkreadyAndLocalize
+            PENALTYSHOOT --> $SecondaryStateTeamDecider
+                OUR --> #GetWalkreadyAndLocalize // we need to also see the goalie todo better use LookForward but this is in dribbling PR
+                OTHER --> #GetWalkreadyAndLookAtBall // goalie only needs to care about the ball
             ELSE --> #StandAndLook
         FINISHED --> #DoNothing
         PLAYING --> $SecondaryStateDecider

--- a/bitbots_body_behavior/src/bitbots_body_behavior/main.dsd
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/main.dsd
@@ -147,7 +147,9 @@ $IsPenalized
     NO --> $GameStateDecider
         INITIAL --> @ChangeAction + action:waiting + r:false, @StandAndWait + duration:1 + r:false, @GetWalkready + r:false, @LookAtFieldFeatures + r:false, @StandAndWait
         READY --> #PositioningReady
-        SET --> #StandAndLook
+        SET --> $SecondaryStateDecider
+            PENALTYSHOOT --> #GetWalkreadyAndLocalize
+            ELSE --> #StandAndLook
         FINISHED --> #DoNothing
         PLAYING --> $SecondaryStateDecider
             PENALTYSHOOT --> #PenaltyBehavior

--- a/bitbots_body_behavior/src/bitbots_body_behavior/main.dsd
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/main.dsd
@@ -8,10 +8,8 @@
 @ChangeAction + action:waiting, @LookAtFieldFeatures, @StandAndWait
 
 #GetWalkreadyAndLocalize
-@ChangeAction + action:waiting + r:false, @StandAndWait + duration:1 + r:false, @GetWalkready + r:false, @LookAtFieldFeatures + r:false, @StandAndWait + duration:2 + r:false, @StandAndWait
+@ChangeAction + action:waiting + r:false, @PlayAnimationInit + r:false, @StandAndWait + duration:2, @GetWalkready + r:false, @LookAtFieldFeatures + r:false, @StandAndWait + duration:2 + r:false, @StandAndWait
 
-#GetWalkreadyAndLookAtBall
-@ChangeAction + action:waiting + r:false, @StandAndWait + duration:1 + r:false, @GetWalkready + r:false, @LookAtBall + r:false, @StandAndWait + duration:2 + r:false, @StandAndWait
 
 #GoAndKickBallMapGoal
 $AvoidBall
@@ -145,12 +143,12 @@ $IsPenalized
     YES --> #DoNothing
     JUST_UNPENALIZED --> #GetWalkreadyAndLocalize
     NO --> $GameStateDecider
-        INITIAL --> @ChangeAction + action:waiting + r:false, @StandAndWait + duration:1 + r:false, @GetWalkready + r:false, @LookAtFieldFeatures + r:false, @StandAndWait + duration:2 + r:false, @StandAndWait
+        INITIAL --> @ChangeAction + action:waiting + r:false, @PlayAnimationInit + r:false, @StandAndWait + duration:2, @GetWalkready + r:false, @LookAtFieldFeatures + r:false, @StandAndWait + duration:2 + r:false, @StandAndWait
         READY --> #PositioningReady
         SET --> $SecondaryStateDecider
             PENALTYSHOOT --> $SecondaryStateTeamDecider
-                OUR --> #GetWalkreadyAndLocalize // we need to also see the goalie todo better use LookForward but this is in dribbling PR
-                OTHER --> #GetWalkreadyAndLookAtBall // goalie only needs to care about the ball
+                OUR -->  @PlayAnimationInit + r:false, @StandAndWait + duration:2, @GetWalkready + r:false, @LookAtFieldFeatures + r:false, @StandAndWait + duration:2 + r:false, @StandAndWait // we need to also see the goalie todo better use LookForward but this is in dribbling PR
+                OTHER -->  @PlayAnimationInit + r:false, @StandAndWait + duration:2, @GetWalkready + r:false, @LookAtBall + r:false, @StandAndWait + duration:2 + r:false, @StandAndWait // goalie only needs to care about the ball
             ELSE --> #StandAndLook
         FINISHED --> #DoNothing
         PLAYING --> $SecondaryStateDecider

--- a/bitbots_body_behavior/src/bitbots_body_behavior/main.dsd
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/main.dsd
@@ -110,12 +110,14 @@ $LocalizationAvailable
     NO --> #NoLocalizationGoalieBehavior
 
 #PenaltyBehavior
-$SecondaryStateTeamDecider
-    OUR --> @KickBallDynamic + r:true  + type:penalty, @LookAtFieldFeatures, @StandAndWait
-    OTHER --> $BallDangerous
-        LEFT --> @PlayAnimationGoalieFallLeft
-        RIGHT --> @PlayAnimationGoalieFallRight
-        ELSE --> @LookAtBall
+$IsPenaltyShootRobot
+    NO --> #DoNothing
+    YES -->$SecondaryStateTeamDecider
+        OUR --> @KickBallDynamic + r:true  + type:penalty, @LookAtFieldFeatures, @StandAndWait
+        OTHER --> $BallDangerous
+            LEFT --> @PlayAnimationGoalieFallLeft
+            RIGHT --> @PlayAnimationGoalieFallRight
+            ELSE --> @LookAtBall
 
 
 #Placing
@@ -147,7 +149,7 @@ $IsPenalized
         READY --> #PositioningReady
         SET --> $SecondaryStateDecider
             PENALTYSHOOT --> $SecondaryStateTeamDecider
-                OUR -->  @DeactivateHCM, @LookForward, @PlayAnimationInit + r:false, @StandAndWait + duration:2, @GetWalkready + r:false, @LookAtFieldFeatures + r:false, @StandAndWait + duration:2 + r:false, @StandAndWait // we need to also see the goalie todo better use LookForward but this is in dribbling PR
+                OUR -->  @DeactivateHCM, @LookForward, @PlayAnimationInit + r:false, @StandAndWait + duration:2, @GetWalkready + r:false, @StandAndWait + duration:2 + r:false, @StandAndWait // we need to also see the goalie todo look at better position a bit lower
                 OTHER --> @DeactivateHCM, @LookForward, @PlayAnimationInit + r:false, @StandAndWait + duration:2, @GetWalkready + r:false, @LookAtBall + r:false, @StandAndWait + duration:2 + r:false, @StandAndWait // goalie only needs to care about the ball
             ELSE --> #StandAndLook
         FINISHED --> #DoNothing

--- a/bitbots_body_behavior/src/bitbots_body_behavior/main.dsd
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/main.dsd
@@ -111,7 +111,7 @@ $LocalizationAvailable
 
 #PenaltyBehavior
 $SecondaryStateTeamDecider
-    OUR --> @LookAtBall, @StandAndWait + duration:1.0, @LookForward + r:false, @KickBallDynamic, @LookAtFieldFeatures + r:false, @StandAndWait + duration:1 + r:false
+    OUR --> @KickBallDynamic, @LookAtFieldFeatures + r:false, @StandAndWait + duration:1 + r:false
     OTHER --> $BallDangerous
         LEFT --> @Stop, @LookAtBall, @PlayAnimationGoalieFallLeft
         RIGHT --> @Stop, @LookAtBall, @PlayAnimationGoalieFallRight

--- a/bitbots_body_behavior/src/bitbots_body_behavior/main.dsd
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/main.dsd
@@ -8,7 +8,7 @@
 @ChangeAction + action:waiting, @LookAtFieldFeatures, @StandAndWait
 
 #GetWalkreadyAndLocalize
-@ChangeAction + action:waiting + r:false, @PlayAnimationInit + r:false, @StandAndWait + duration:2, @GetWalkready + r:false, @LookAtFieldFeatures + r:false, @StandAndWait + duration:2 + r:false, @StandAndWait
+@ChangeAction + action:waiting + r:false, @LookForward, @PlayAnimationInit + r:false, @StandAndWait + duration:2, @GetWalkready + r:false, @LookAtFieldFeatures + r:false, @StandAndWait + duration:2 + r:false, @StandAndWait
 
 
 #GoAndKickBallMapGoal
@@ -111,7 +111,7 @@ $LocalizationAvailable
 
 #PenaltyBehavior
 $SecondaryStateTeamDecider
-    OUR --> @KickBallDynamic, @LookAtFieldFeatures + r:false, @StandAndWait + duration:1 + r:false
+    OUR --> @KickBallDynamic, @LookAtFieldFeatures, @StandAndWait + duration:1
     OTHER --> $BallDangerous
         LEFT --> @Stop, @LookAtBall, @PlayAnimationGoalieFallLeft
         RIGHT --> @Stop, @LookAtBall, @PlayAnimationGoalieFallRight
@@ -143,12 +143,12 @@ $IsPenalized
     YES --> #DoNothing
     JUST_UNPENALIZED --> #GetWalkreadyAndLocalize
     NO --> $GameStateDecider
-        INITIAL --> @ChangeAction + action:waiting + r:false, @PlayAnimationInit + r:false, @StandAndWait + duration:2, @GetWalkready + r:false, @LookAtFieldFeatures + r:false, @StandAndWait + duration:2 + r:false, @StandAndWait
+        INITIAL --> @ChangeAction + action:waiting + r:false, @LookForward, @PlayAnimationInit + r:false, @StandAndWait + duration:2, @GetWalkready + r:false, @LookAtFieldFeatures + r:false, @StandAndWait + duration:2 + r:false, @StandAndWait
         READY --> #PositioningReady
         SET --> $SecondaryStateDecider
             PENALTYSHOOT --> $SecondaryStateTeamDecider
-                OUR -->  @PlayAnimationInit + r:false, @StandAndWait + duration:2, @GetWalkready + r:false, @LookAtFieldFeatures + r:false, @StandAndWait + duration:2 + r:false, @StandAndWait // we need to also see the goalie todo better use LookForward but this is in dribbling PR
-                OTHER -->  @PlayAnimationInit + r:false, @StandAndWait + duration:2, @GetWalkready + r:false, @LookAtBall + r:false, @StandAndWait + duration:2 + r:false, @StandAndWait // goalie only needs to care about the ball
+                OUR -->  @LookForward, @PlayAnimationInit + r:false, @StandAndWait + duration:2, @GetWalkready + r:false, @LookAtFieldFeatures + r:false, @StandAndWait + duration:2 + r:false, @StandAndWait // we need to also see the goalie todo better use LookForward but this is in dribbling PR
+                OTHER --> @LookForward, @PlayAnimationInit + r:false, @StandAndWait + duration:2, @GetWalkready + r:false, @LookAtBall + r:false, @StandAndWait + duration:2 + r:false, @StandAndWait // goalie only needs to care about the ball
             ELSE --> #StandAndLook
         FINISHED --> #DoNothing
         PLAYING --> $SecondaryStateDecider

--- a/bitbots_body_behavior/src/bitbots_body_behavior/main.dsd
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/main.dsd
@@ -8,7 +8,7 @@
 @ChangeAction + action:waiting, @LookAtFieldFeatures, @StandAndWait
 
 #GetWalkreadyAndLocalize
-@ChangeAction + action:waiting + r:false, @GetWalkready + r:false, @LookAtFieldFeatures + r:false, @StandAndWait + duration:2 + r:false
+@ChangeAction + action:waiting + r:false, @StandAndWait + duration:1 + r:false, @GetWalkready + r:false, @LookAtFieldFeatures + r:false, @StandAndWait + duration:2 + r:false
 
 #GoAndKickBallMapGoal
 $AvoidBall
@@ -145,7 +145,7 @@ $IsPenalized
     YES --> #DoNothing
     JUST_UNPENALIZED --> #GetWalkreadyAndLocalize
     NO --> $GameStateDecider
-        INITIAL --> @ChangeAction + action:waiting + r:false, @GetWalkready + r:false, @LookAtFieldFeatures + r:false, @StandAndWait
+        INITIAL --> @ChangeAction + action:waiting + r:false, @StandAndWait + duration:1 + r:false, @GetWalkready + r:false, @LookAtFieldFeatures + r:false, @StandAndWait
         READY --> #PositioningReady
         SET --> #StandAndLook
         FINISHED --> #DoNothing

--- a/bitbots_body_behavior/src/bitbots_body_behavior/main.dsd
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/main.dsd
@@ -111,7 +111,7 @@ $LocalizationAvailable
 
 #PenaltyBehavior
 $SecondaryStateTeamDecider
-    OUR --> @KickBallDynamic + r:true, @LookAtFieldFeatures, @StandAndWait + duration:1
+    OUR --> @KickBallDynamic + r:true + type:penalty, @LookAtFieldFeatures, @StandAndWait + duration:1
     OTHER --> $BallDangerous
         LEFT --> @Stop, @LookAtBall, @PlayAnimationGoalieFallLeft
         RIGHT --> @Stop, @LookAtBall, @PlayAnimationGoalieFallRight


### PR DESCRIPTION
## Proposed changes
With this change, after penalty and in initial, we wait for one second before we go to walkready. This is necessary because we are not allowed to move our motors for the first second in these situations, so we cannot immediately start to go to walkready.

## Related issues
Follow-up on #198.

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

