### PR TITLE
add random time for penalty kicker

### DIFF
--- a/bitbots_body_behavior/src/bitbots_body_behavior/actions/stand.py
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/actions/stand.py
@@ -1,3 +1,5 @@
+import random
+
 import rospy
 from tf2_geometry_msgs import PoseStamped
 
@@ -27,3 +29,15 @@ class StandAndWait(AbstractActionElement):
             return self.pop()
 
         self.blackboard.pathfinding.cancel_goal()
+
+
+class StandAndWaitRandom(StandAndWait):
+    """ This stops the robots walking and keeps standing """
+
+    def __init__(self, blackboard, dsd, parameters=None):
+        super().__init__(blackboard, dsd, parameters)
+        self.min = parameters.get('min', None)
+        self.max = parameters.get('max', None)
+        self.duration = random.uniform(self.min, self.max)
+
+        self.start_time = rospy.Time.now()

--- a/bitbots_body_behavior/src/bitbots_body_behavior/main.dsd
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/main.dsd
@@ -107,7 +107,7 @@ $LocalizationAvailable
 $IsPenaltyShootRobot
     NO --> #DoNothing
     YES -->$SecondaryStateTeamDecider
-        OUR --> @KickBallDynamic + r:true + type:penalty, @StandAndWait
+        OUR --> @StandAndWaitRandom + min:10 + max:30, @KickBallDynamic + r:true + type:penalty, @StandAndWait
         OTHER --> $BallDangerous
             LEFT --> @PlayAnimationGoalieFallLeft
             RIGHT --> @PlayAnimationGoalieFallRight


### PR DESCRIPTION
## Proposed changes
Make penalty kicker wait a bit before kicking, so that goalies which just throw themselves without actually looking at the ball get a penalty before.


## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

