### PR TITLE
Better placing fieldplayer

### DIFF
--- a/bitbots_blackboard/src/bitbots_blackboard/capsules/pathfinding_capsule.py
+++ b/bitbots_blackboard/src/bitbots_blackboard/capsules/pathfinding_capsule.py
@@ -18,6 +18,7 @@ class PathfindingCapsule:
         self.pathfinding_pub = None  # type: rospy.Publisher
         self.pathfinding_cancel_pub = None  # type: rospy.Publisher
         self.ball_obstacle_active_pub = None
+        self.keep_out_area_pub = None
         self.approach_marker_pub = None
         self.goal = None  # type: PoseStamped
         self.current_pose = None # type: PoseStamped
@@ -79,3 +80,7 @@ class PathfindingCapsule:
 
     def cancel_goal(self):
         self.pathfinding_cancel_pub.publish(GoalID())
+
+    def publish_keep_out_area(self, x, y):
+        """Publishes a keep out area with 1m radius for placing"""
+

--- a/bitbots_blackboard/src/bitbots_blackboard/capsules/pathfinding_capsule.py
+++ b/bitbots_blackboard/src/bitbots_blackboard/capsules/pathfinding_capsule.py
@@ -80,7 +80,3 @@ class PathfindingCapsule:
 
     def cancel_goal(self):
         self.pathfinding_cancel_pub.publish(GoalID())
-
-    def publish_keep_out_area(self, x, y):
-        """Publishes a keep out area with 1m radius for placing"""
-

--- a/bitbots_body_behavior/config/body_behavior.yaml
+++ b/bitbots_body_behavior/config/body_behavior.yaml
@@ -36,7 +36,7 @@ behavior:
       offense: [ [ -0.25, 0 ], [ -0.075, 0.33 ], [ -0.075, -0.33 ] ]
       kickoff: [ -0.1, 0 ]
       # position number 0 = center, 1 = left, 2 = right
-      pos_number: 0
+      pos_number: 0 #this is currently handled more dynamically for offense players
 
     # Time to wait in ready state before moving to role position to give the localization time to converge.
     ready_wait_time: 4

--- a/bitbots_body_behavior/src/bitbots_body_behavior/actions/go_to_defense_position.py
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/actions/go_to_defense_position.py
@@ -43,18 +43,34 @@ class GoToDefensePosition(AbstractActionElement):
 
         goal_position = (-self.blackboard.world_model.field_length / 2, 0)  # position of the own goal
         ball_position = self.blackboard.world_model.get_ball_position_xy()
+        our_pose = self.blackboard.world_model.get_current_position()
 
         pose_msg = PoseStamped()
         pose_msg.header.stamp = rospy.Time.now()
         pose_msg.header.frame_id = self.blackboard.map_frame
 
-        if self.mode == "freekick":
+        if self.mode == "freekick_first":
             vector_ball_to_goal = np.array(goal_position) - np.array(ball_position)
             # pos between ball and goal but 1m away from ball
             defense_pos = vector_ball_to_goal / np.linalg.norm(vector_ball_to_goal) * 1 + np.array(ball_position)
             pose_msg.pose.position.x = defense_pos[0]
             pose_msg.pose.position.y = defense_pos[1]
             yaw = math.atan(-vector_ball_to_goal[1] / -vector_ball_to_goal[0])
+            pose_msg.pose.orientation = Quaternion(*quaternion_from_euler(0, 0, yaw))
+        elif self.mode == "freekick_second":
+            vector_ball_to_goal = np.array(goal_position) - np.array(ball_position)
+            # pos between ball and goal but 1m away from ball and 1m to the side which is closer to us
+            defense_pos = vector_ball_to_goal / np.linalg.norm(vector_ball_to_goal) * 1 + np.array(ball_position)
+            yaw = math.atan(-vector_ball_to_goal[1] / -vector_ball_to_goal[0])
+
+            # decide on side
+            if our_pose[1] < ball_position[1]:
+                side_sign = -1
+            else:
+                side_sign = 1
+
+            pose_msg.pose.position.x = defense_pos[0] + side_sign * math.sin(yaw) * 1
+            pose_msg.pose.position.y = defense_pos[1] + side_sign * math.cos(yaw) * 1
             pose_msg.pose.orientation = Quaternion(*quaternion_from_euler(0, 0, yaw))
         else:
             # center point between ball and own goal

--- a/bitbots_body_behavior/src/bitbots_body_behavior/actions/go_to_defense_position.py
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/actions/go_to_defense_position.py
@@ -65,7 +65,7 @@ class GoToDefensePosition(AbstractActionElement):
 
             # decide on side that is closer
             pos_1 = np.array([defense_pos[0] + math.sin(yaw) * 1, defense_pos[1] + math.cos(yaw) * 1])
-            pos_2 = np.array([defense_pos[0] + math.sin(yaw) * 1, defense_pos[1] - math.cos(yaw) * 1])
+            pos_2 = np.array([defense_pos[0] - math.sin(yaw) * 1, defense_pos[1] - math.cos(yaw) * 1])
             distance_1 = np.linalg.norm(our_pose - pos_1)
             distance_2 = np.linalg.norm(our_pose - pos_2)
 

--- a/bitbots_body_behavior/src/bitbots_body_behavior/actions/go_to_defense_position.py
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/actions/go_to_defense_position.py
@@ -43,7 +43,8 @@ class GoToDefensePosition(AbstractActionElement):
 
         goal_position = (-self.blackboard.world_model.field_length / 2, 0)  # position of the own goal
         ball_position = self.blackboard.world_model.get_ball_position_xy()
-        our_pose = np.array(self.blackboard.world_model.get_current_position())
+        robot_x, robot_y, _ = np.array(self.blackboard.world_model.get_current_position())
+        our_pose = [robot_x, robot_y]
 
         pose_msg = PoseStamped()
         pose_msg.header.stamp = rospy.Time.now()

--- a/bitbots_body_behavior/src/bitbots_body_behavior/actions/go_to_role_position.py
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/actions/go_to_role_position.py
@@ -1,3 +1,5 @@
+import random
+
 import rospy
 from tf2_geometry_msgs import PoseStamped
 from geometry_msgs.msg import Point
@@ -12,9 +14,14 @@ class GoToRolePosition(AbstractActionElement):
         try:
             if self.blackboard.blackboard.duty == 'goalie':
                 generalized_role_position = role_positions[self.blackboard.blackboard.duty]
-            elif self.blackboard.blackboard.duty == 'offense' and role_positions['pos_number'] == 0 and self.blackboard.gamestate.has_kickoff():
+            elif self.blackboard.blackboard.duty == 'offense' and role_positions['pos_number'] == 0 \
+                    and self.blackboard.gamestate.has_kickoff():
                 # handle kick off specifically. Let center offense go near ball
                 generalized_role_position = role_positions['kickoff']
+            elif self.blackboard.blackboard.duty == 'offense' and role_positions['pos_number'] != 0:
+                # chose position randomly between left and right
+                random_number = random.randint(1, 2)
+                generalized_role_position = role_positions[self.blackboard.blackboard.duty][random_number]
             else:
                 # players other than the goalie have multiple possible positions
                 generalized_role_position = \

--- a/bitbots_body_behavior/src/bitbots_body_behavior/actions/publish_keep_out_area.py
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/actions/publish_keep_out_area.py
@@ -22,7 +22,7 @@ class PublishKeepOutArea(AbstractActionElement):
 
         dummy_header = Header()
         dummy_header.stamp = rospy.Time.now()
-        dummy_header.frame_id = self.map_frame
+        dummy_header.frame_id = self.blackboard.map_frame
         msg = create_cloud_xyz32(dummy_header, obstacle_points)
-        self.blackboard.keep_out_area_pub.publish(msg)
+        self.blackboard.pathfinding.keep_out_area_pub.publish(msg)
         self.pop()

--- a/bitbots_body_behavior/src/bitbots_body_behavior/actions/publish_keep_out_area.py
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/actions/publish_keep_out_area.py
@@ -14,6 +14,7 @@ class PublishKeepOutArea(AbstractActionElement):
 
         # we need to create multiple points since we can not set the inflation for only this layer
         points_distance = 0.5
+        # todo these positions could be improved. maybe use linspace
         obstacle_points = [[ball_position[0], ball_position[1], 0],
                            [ball_position[0] + points_distance, ball_position[1] + points_distance, 0],
                            [ball_position[0] - points_distance, ball_position[1] + points_distance, 0],

--- a/bitbots_body_behavior/src/bitbots_body_behavior/actions/publish_keep_out_area.py
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/actions/publish_keep_out_area.py
@@ -1,0 +1,28 @@
+import rospy
+from dynamic_stack_decider import AbstractActionElement
+from humanoid_league_msgs.msg import Strategy
+from sensor_msgs.point_cloud2 import create_cloud_xyz32
+from std_msgs.msg import Header
+
+
+class PublishKeepOutArea(AbstractActionElement):
+    def __init__(self, blackboard, dsd, parameters):
+        super().__init__(blackboard, dsd, parameters)
+
+    def perform(self, reevaluate=False):
+        ball_position = self.blackboard.world_model.get_ball_position_xy()
+
+        # we need to create multiple points since we can not set the inflation for only this layer
+        points_distance = 0.5
+        obstacle_points = [[ball_position[0], ball_position[1], 0],
+                           [ball_position[0] + points_distance, ball_position[1] + points_distance, 0],
+                           [ball_position[0] - points_distance, ball_position[1] + points_distance, 0],
+                           [ball_position[0] + points_distance, ball_position[1] - points_distance, 0],
+                           [ball_position[0] - points_distance, ball_position[1] - points_distance, 0]]
+
+        dummy_header = Header()
+        dummy_header.stamp = rospy.Time.now()
+        dummy_header.frame_id = self.map_frame
+        msg = create_cloud_xyz32(dummy_header, obstacle_points)
+        self.blackboard.keep_out_area_pub.publish(msg)
+        self.pop()

--- a/bitbots_body_behavior/src/bitbots_body_behavior/body_behavior.py
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/body_behavior.py
@@ -35,6 +35,7 @@ if __name__ == "__main__":
     D.blackboard.pathfinding.pathfinding_pub = rospy.Publisher('move_base_simple/goal', PoseStamped, queue_size=1)
     D.blackboard.pathfinding.pathfinding_cancel_pub = rospy.Publisher('move_base/cancel', GoalID, queue_size=1)
     D.blackboard.pathfinding.ball_obstacle_active_pub = rospy.Publisher("ball_obstacle_active", Bool, queue_size=1)
+    D.blackboard.pathfinding.keep_out_area_pub = rospy.Publisher("keep_out_area", PointCloud2, queue_size=1)
     D.blackboard.pathfinding.approach_marker_pub = rospy.Publisher("debug/approach_point", Marker, queue_size=10)
 
     D.blackboard.dynup_cancel_pub = rospy.Publisher('dynup/cancel', GoalID, queue_size=1)

--- a/bitbots_body_behavior/src/bitbots_body_behavior/decisions/do_once.py
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/decisions/do_once.py
@@ -1,0 +1,19 @@
+import rospy
+
+from dynamic_stack_decider.abstract_decision_element import AbstractDecisionElement
+
+
+class DoOnce(AbstractDecisionElement):
+    def __init__(self, blackboard, dsd, parameters=None):
+        super().__init__(blackboard, dsd, parameters)
+        self.done = False
+
+    def perform(self, reevaluate=False):
+        if self.done:
+            return 'DONE'
+        else:
+            self.done = True
+            return 'NOT_DONE'
+
+    def get_reevaluate(self):
+        return False

--- a/bitbots_body_behavior/src/bitbots_body_behavior/decisions/kick_off_time_up.py
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/decisions/kick_off_time_up.py
@@ -24,9 +24,13 @@ class KickOffTimeUp(AbstractDecisionElement):
                         abs(ball_pos[1]) > self.kickoff_min_ball_movement:
                     self.publish_debug_data("Reason", "Opp kick off ball moved")
                     return 'YES'
+            else:
+                # this is some kind of free kick and we may want to act differently
+                self.publish_debug_data("Reason", "Opp has free kick")
+                return 'NO_FREEKICK'
             self.publish_debug_data("Reason", "Opp has kick off")
             # we need to wait for now
-            return 'NO'
+            return 'NO_NORMAL'
 
     def get_reevaluate(self):
         return True

--- a/bitbots_body_behavior/src/bitbots_body_behavior/main.dsd
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/main.dsd
@@ -155,13 +155,16 @@ $IsPenalized
             TIMEOUT --> #StandAndLook
             ELSE --> $SecondaryStateModeDecider
                 ELSE --> #StandAndLook
-                PLACING --> #Placing
+                PLACING --> $DoOnce
+                    NOT_DONE --> @PublishKeepOutArea
+                    DONE --> #Placing
             NORMAL --> $BallSeen
                 NO --> $ConfigRole
                     GOALIE --> @GoToRolePosition
                     ELSE --> #SearchBall
                 YES --> $KickOffTimeUp
-                    NO --> #StandAndLook
+                    NO_NORMAL --> #StandAndLook
+                    NO_FREEKICK --> #Placing
                     YES --> $ConfigRole
                         GOALIE --> #GoalieRole
                         ELSE --> $LocalizationAvailable

--- a/bitbots_body_behavior/src/bitbots_body_behavior/main.dsd
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/main.dsd
@@ -8,7 +8,7 @@
 @ChangeAction + action:waiting, @LookAtFieldFeatures, @StandAndWait
 
 #GetWalkreadyAndLocalize
-@ChangeAction + action:waiting + r:false, @LookForward + r:false, @PlayAnimationInit + r:false, @StandAndWait + duration:2 + r:false, @GetWalkready + r:false, @LookAtFieldFeatures + r:false, @StandAndWait + duration:2 + r:false, @StandAndWait
+@ChangeAction + action:waiting + r:false, @LookForward + r:false, @PlayAnimationInit + r:false, @GetWalkready + r:false, @LookAtFieldFeatures + r:false, @StandAndWait + duration:2 + r:false, @StandAndWait
 
 
 #GoAndKickBallMapGoal
@@ -133,8 +133,8 @@ $ConfigRole
                     SECOND --> @ChangeAction + action:positioning, @LookAtFieldFeatures, @AvoidBallActive, @GoToPassPreparePosition
                     THIRD --> @ChangeAction + action:positioning, @LookAtFieldFeatures, @AvoidBallActive, @GoToDefensePosition
                 OTHER --> $RankToBallNoGoalie
-                    FIRST --> @ChangeAction + action:positioning, @LookAtFieldFeatures, @AvoidBallActive, @GoToBall + target:map_goal + distance:1
-                    SECOND --> @ChangeAction + action:positioning, @LookAtFieldFeatures, @AvoidBallActive, @GoToDefensePosition + mode:freekick
+                    FIRST --> @ChangeAction + action:positioning, @LookAtFieldFeatures, @AvoidBallActive, @GoToDefensePosition + mode:freekick_first
+                    SECOND --> @ChangeAction + action:positioning, @LookAtFieldFeatures, @AvoidBallActive, @GoToDefensePosition + mode:freekick_second
                     THIRD --> @ChangeAction + action:positioning, @LookAtFieldFeatures, @AvoidBallActive, @GoToDefensePosition
 
 -->BodyBehavior
@@ -142,7 +142,7 @@ $IsPenalized
     YES --> #DoNothing
     JUST_UNPENALIZED --> #GetWalkreadyAndLocalize
     NO --> $GameStateDecider
-        INITIAL --> @ChangeAction + action:waiting + r:false, @LookForward + r:false, @PlayAnimationInit + r:false, @StandAndWait + duration:2, @GetWalkready + r:false, @LookAtFieldFeatures + r:false, @StandAndWait + duration:2 + r:false, @StandAndWait
+        INITIAL --> @ChangeAction + action:waiting + r:false, @LookForward + r:false, @PlayAnimationInit + r:false, @GetWalkready + r:false, @LookAtFieldFeatures + r:false, @StandAndWait + duration:2 + r:false, @StandAndWait
         READY --> #PositioningReady
         SET --> $SecondaryStateDecider
             PENALTYSHOOT --> $SecondaryStateTeamDecider

--- a/bitbots_body_behavior/src/bitbots_body_behavior/main.dsd
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/main.dsd
@@ -155,9 +155,11 @@ $IsPenalized
             TIMEOUT --> #StandAndLook
             ELSE --> $SecondaryStateModeDecider
                 ELSE --> #StandAndLook
-                PLACING --> $DoOnce
-                    NOT_DONE --> @PublishKeepOutArea
-                    DONE --> #Placing
+                PLACING --> $SecondaryStateTeamDecider
+                    OUR --> #Placing
+                    OTHER --> $DoOnce
+                        NOT_DONE --> @PublishKeepOutArea
+                        DONE --> #Placing
             NORMAL --> $BallSeen
                 NO --> $ConfigRole
                     GOALIE --> @GoToRolePosition

--- a/bitbots_body_behavior/src/bitbots_body_behavior/main.dsd
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/main.dsd
@@ -155,11 +155,7 @@ $IsPenalized
             TIMEOUT --> #StandAndLook
             ELSE --> $SecondaryStateModeDecider
                 ELSE --> #StandAndLook
-                PLACING --> $SecondaryStateTeamDecider
-                    OUR --> #Placing
-                    OTHER --> $DoOnce
-                        NOT_DONE --> @PublishKeepOutArea
-                        DONE --> #Placing
+                PLACING --> #Placing
             NORMAL --> $BallSeen
                 NO --> $ConfigRole
                     GOALIE --> @GoToRolePosition

--- a/bitbots_body_behavior/src/bitbots_body_behavior/main.dsd
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/main.dsd
@@ -146,8 +146,8 @@ $IsPenalized
         READY --> #PositioningReady
         SET --> $SecondaryStateDecider
             PENALTYSHOOT --> $SecondaryStateTeamDecider
-                OUR -->  @DeactivateHCM + r:false,, @LookForward + r:false,, @PlayAnimationInit + r:false, @GetWalkready + r:false, @StandAndWait // we need to also see the goalie
-                OTHER --> @DeactivateHCM + r:false,, @LookForward + r:false,, @PlayAnimationInit + r:false, @GetWalkready + r:false, @LookAtBall + r:false, @PlayAnimationGoalieArms + r:false, @StandAndWait // goalie only needs to care about the ball
+                OUR -->  @DeactivateHCM + r:false, @LookForward + r:false, @PlayAnimationInit + r:false, @GetWalkready + r:false, @StandAndWait // we need to also see the goalie
+                OTHER --> @DeactivateHCM + r:false, @LookForward + r:false, @PlayAnimationInit + r:false, @GetWalkready + r:false, @LookAtBall + r:false, @PlayAnimationGoalieArms + r:false, @StandAndWait // goalie only needs to care about the ball
             ELSE --> #StandAndLook
         FINISHED --> #DoNothing
         PLAYING --> $SecondaryStateDecider


### PR DESCRIPTION
## Proposed changes
Improves placing positions of the field player and publishes keep out area during placing so that we are not to close to the ball when placing ends.
needs https://github.com/bit-bots/bitbots_navigation/pull/142

Keep out area obstacles are published but somehow not used in costmap. I don't know why. It is deactivated for now anyway since we would have issues when we are inside the obstacle. I open an issue for that so that we can do it after the competition
![keep_out](https://user-images.githubusercontent.com/11520148/122771691-f3b40f00-d2a6-11eb-863d-8f999500f544.png)


## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Put the PR on our Project board

