### PR TITLE
Reduce ball approach distance

### DIFF
--- a/bitbots_body_behavior/config/body_behavior.yaml
+++ b/bitbots_body_behavior/config/body_behavior.yaml
@@ -136,7 +136,7 @@ behavior:
     ball_reaproach_dist: 1.0
 
     # Distance at which the ball is normally approached
-    ball_approach_dist: 0.24
+    ball_approach_dist: 0.2
 
     # Angle at which the ball is normally approached again
     ball_reapproach_angle: 1.2


### PR DESCRIPTION
## Proposed changes
This PR reduces the ball approach distance to avoid problems where the ball is too far for the kick area but too close to walk closer.

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

