### PR TITLE
Add simple static test for behavior

### DIFF
--- a/bitbots_body_behavior/CMakeLists.txt
+++ b/bitbots_body_behavior/CMakeLists.txt
@@ -8,3 +8,8 @@ catkin_python_setup()
 catkin_package()
 
 enable_bitbots_docs()
+
+if (CATKIN_ENABLE_TESTING)
+    find_package(catkin REQUIRED COMPONENTS bitbots_test)
+    enable_bitbots_tests()
+endif()

--- a/bitbots_body_behavior/package.xml
+++ b/bitbots_body_behavior/package.xml
@@ -25,6 +25,7 @@
   <exec_depend>ros_numpy</exec_depend>
   <exec_depend>tf2</exec_depend>
   <exec_depend>bitbots_convenience_frames</exec_depend>
+  <test_depend>bitbots_test</test_depend>
 
 
   <export>

--- a/bitbots_body_behavior/test/rostests/test_dsd_file.launch
+++ b/bitbots_body_behavior/test/rostests/test_dsd_file.launch
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<launch>
+    <rosparam command="load" file="$(find bitbots_body_behavior)/config/body_behavior.yaml" />
+    <rosparam command="load" file="$(find bitbots_body_behavior)/config/animations.yaml" />
+    <test pkg="bitbots_body_behavior" type="test_dsd_file.py" test-name="dsd_file" />
+</launch>

--- a/bitbots_body_behavior/test/rostests/test_dsd_file.py
+++ b/bitbots_body_behavior/test/rostests/test_dsd_file.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+from bitbots_test.test_case import RosNodeTestCase
+from dynamic_stack_decider import DSD
+from bitbots_blackboard.blackboard import BodyBlackboard
+from pathlib import Path
+import rospy
+import rospkg
+
+class DsdFileTestCase(RosNodeTestCase):
+    def test_dsd_valid(self):
+        D = DSD(BodyBlackboard())
+        behavior_dir = Path(rospkg.RosPack().get_path('bitbots_body_behavior')) / 'src' / 'bitbots_body_behavior'
+        D.register_actions(behavior_dir / 'actions')
+        D.register_decisions(behavior_dir / 'decisions')
+        D.load_behavior(behavior_dir / 'main.dsd')
+
+
+if __name__ == '__main__':
+    from bitbots_test import run_rostests
+    run_rostests(DsdFileTestCase)


### PR DESCRIPTION
## Proposed changes
This adds a very simple test to the behavior. While it does not execute any actual code of the behavior, the dsd file is created and an instance of the blackboard is created. This makes sure that

- the dsd file is valid
- all actions and decisions in the dsd file exist
- all parameters accessed in the blackboard are set in the behavior config

If any of these conditions is not fulfilled, an exception is raised, therefore no asserts are necessary.

## Related issues
This test would have caught the issue that led to us not playing in the games TEST72 and TEST75.

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

