### PR TITLE
will let the supporter keep a bigger margin to the middle line

### DIFF
--- a/bitbots_body_behavior/config/body_behavior.yaml
+++ b/bitbots_body_behavior/config/body_behavior.yaml
@@ -33,7 +33,7 @@ behavior:
     role_positions:
       goalie: [ -0.95, 0 ]
       defense: [ [ -0.5, 0 ], [ -0.45, 0.5 ], [ -0.45, -0.5 ] ]
-      offense: [ [ -0.3, 0 ], [ -0.075, 0.33 ], [ -0.075, -0.33 ] ]
+      offense: [ [ -0.3, 0 ], [ -0.09, 0.33 ], [ -0.09, -0.33 ] ]
       kickoff: [ -0.1, 0 ]
       # position number 0 = center, 1 = left, 2 = right
       pos_number: 0 #this is currently handled more dynamically for offense players


### PR DESCRIPTION
## Proposed changes
<!--- Describe your changes and why they are necessary. -->
We keep a very slightly larger distance to the middle line so we don't risk running into it while we walk in place.
New position looks like this at the beginning of set:
![image](https://user-images.githubusercontent.com/31103663/123072871-35af9300-d416-11eb-9b44-fc8f5cd2841e.png)

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
might not be necessary after #226 

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [X] Test on your machine
- [ ] Test on the robot
- [ ] Put the PR on our Project board

