### PR TITLE
Fix hybrid goalie in free kick placing

### DIFF
--- a/bitbots_body_behavior/src/bitbots_body_behavior/main.dsd
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/main.dsd
@@ -121,7 +121,9 @@ $IsPenaltyShootRobot
 
 #Placing
 $ConfigRole
-    GOALIE --> @ChangeAction + action:positioning, @GoToBlockPosition, @LookAtFieldFeatures
+    GOALIE --> $BallInOwnPercent + p:33
+        YES --> @ChangeAction + action:positioning, @GoToBlockPosition, @LookAtFieldFeatures
+        NO -->  @ChangeAction + action:positioning, @GoToDefensePosition, @LookAtFieldFeatures
     ELSE --> $BallSeen
         NO --> #SearchBall
         YES --> $SecondaryStateDecider


### PR DESCRIPTION
## Proposed changes
Currently, the hybrid goalie always goes to the block position (i.e. in the goal) during the placing phase of free kicks. This pull request changes the behavior to go to the defense position instead when the ball is far enough away from the goal.

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

