### PR TITLE
if goalie doesn't see ball, still look at field features

### DIFF
--- a/bitbots_body_behavior/src/bitbots_body_behavior/main.dsd
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/main.dsd
@@ -171,7 +171,7 @@ $IsPenalized
                 PLACING --> #Placing
             NORMAL --> $BallSeen
                 NO --> $ConfigRole
-                    GOALIE --> @GoToRolePosition
+                    GOALIE --> @LookAtFieldFeatures, @GoToRolePosition
                     ELSE --> #SearchBall
                 YES --> $KickOffTimeUp
                     NO_NORMAL --> #StandAndLook


### PR DESCRIPTION
## Proposed changes
<!--- Describe your changes and why they are necessary. -->
If the goalie runs back to their goal in Normal, they just execute go to role position. We should also look the field features meanwhile.

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [X] Test on your machine
- [ ] Test on the robot
- [ ] Put the PR on our Project board

