### PR TITLE
Fix switching between walkready and init in init phase

### DIFF
--- a/bitbots_body_behavior/src/bitbots_body_behavior/main.dsd
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/main.dsd
@@ -147,7 +147,9 @@ $ConfigRole
 -->BodyBehavior
 $IsPenalized
     YES --> #DoNothing
-    JUST_UNPENALIZED --> #GetWalkreadyAndLocalize
+    JUST_UNPENALIZED --> $GameStateDecider
+        INITIAL --> #Init
+        ELSE --> #GetWalkreadyAndLocalize
     NO --> $GameStateDecider
         INITIAL --> #Init
         READY --> $AnyGoalScoreRecently + time:50


### PR DESCRIPTION
## Proposed changes
Changes a decision in the main.dsd that keeps the robot from changing between walkready and init pose during init
<!--- Describe your changes and why they are necessary. -->

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Put the PR on our Project board

