### PR TITLE
Fix forget ball

### DIFF
--- a/bitbots_body_behavior/src/bitbots_body_behavior/actions/forget_ball.py
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/actions/forget_ball.py
@@ -3,5 +3,5 @@ from dynamic_stack_decider.abstract_action_element import AbstractActionElement
 
 class ForgetBall(AbstractActionElement):
     def perform(self, reevaluate=False):
-        self.blackboard.world_model.forget_ball()
+        self.blackboard.world_model.forget_ball(own=True, team=True, reset_ball_filter=True)
         self.pop()

--- a/bitbots_body_behavior/src/bitbots_body_behavior/actions/kick_ball.py
+++ b/bitbots_body_behavior/src/bitbots_body_behavior/actions/kick_ball.py
@@ -10,7 +10,7 @@ from dynamic_stack_decider.abstract_action_element import AbstractActionElement
 
 class AbstractKickAction(AbstractActionElement):
     def pop(self):
-        self.blackboard.world_model.forget_ball()
+        self.blackboard.world_model.forget_ball(own=True, team=True, reset_ball_filter=True)
         super(AbstractKickAction, self).pop()
 
 


### PR DESCRIPTION
## Proposed changes
The ball filter resets the ball correctly and publishes a filtered ball at the same position but with a high covariance.
The behavior afterwards just ignored the new ball because of it's high covariance, but did not reset / forget the old internal ball.
This fixes the issue by forgetting the ball after receiving a incoming ball with high covariance.

## Related issues
#233
