### PR TITLE
Fix defense position

### DIFF
--- a/bitbots_body_behavior/bitbots_body_behavior/actions/deactivate_hcm.py
+++ b/bitbots_body_behavior/bitbots_body_behavior/actions/deactivate_hcm.py
@@ -10,5 +10,5 @@ class DeactivateHCM(AbstractActionElement):
         super().__init__(blackboard, dsd, parameters)
 
     def perform(self, reevaluate=False):
-        self.blackboard.hcm_deactivate_pub.publish(Bool(True))
+        self.blackboard.hcm_deactivate_pub.publish(Bool(data=True))
         self.pop()

--- a/bitbots_body_behavior/bitbots_body_behavior/actions/go_to_defense_position.py
+++ b/bitbots_body_behavior/bitbots_body_behavior/actions/go_to_defense_position.py
@@ -61,7 +61,6 @@ class GoToDefensePosition(AbstractActionElement):
             yaw = math.atan(-vector_ball_to_goal[1] / -vector_ball_to_goal[0])
             x, y, z, w = quaternion_from_euler(0, 0, yaw)
             pose_msg.pose.orientation = Quaternion(x=x, y=y, z=z, w=w)
-            #pose_msg.pose.orientation = Quaternion(*quaternion_from_euler(0, 0, yaw))
         elif self.mode == "freekick_second":
             vector_ball_to_goal = np.array(goal_position) - np.array(ball_position)
             # pos between ball and goal but 1.5m away from ball and 1m to the side which is closer to us

--- a/bitbots_body_behavior/bitbots_body_behavior/actions/go_to_defense_position.py
+++ b/bitbots_body_behavior/bitbots_body_behavior/actions/go_to_defense_position.py
@@ -81,7 +81,6 @@ class GoToDefensePosition(AbstractActionElement):
                 pose_msg.pose.position.y = pos_2[1]
             x, y, z, w = quaternion_from_euler(0, 0, yaw)
             pose_msg.pose.orientation = Quaternion(x=x, y=y, z=z, w=w)
-            #pose_msg.pose.orientation = Quaternion(*quaternion_from_euler(0, 0, yaw))
         else:
             # center point between ball and own goal
             pose_msg.pose.position.x = (goal_position[0] + ball_position[0]) / 2

--- a/bitbots_body_behavior/bitbots_body_behavior/actions/go_to_defense_position.py
+++ b/bitbots_body_behavior/bitbots_body_behavior/actions/go_to_defense_position.py
@@ -19,7 +19,7 @@ class GoToDefensePosition(AbstractActionElement):
         self.position_number = role_positions['pos_number']
         try:
             generalized_role_position = \
-                role_positions['defense'][self.position_number]
+                role_positions[f'defense_{self.position_number}']
         except KeyError:
             raise KeyError('Role position for {} not specified in config'.format(self.blackboard.blackboard.duty))
 
@@ -59,7 +59,9 @@ class GoToDefensePosition(AbstractActionElement):
             pose_msg.pose.position.x = defense_pos[0]
             pose_msg.pose.position.y = defense_pos[1]
             yaw = math.atan(-vector_ball_to_goal[1] / -vector_ball_to_goal[0])
-            pose_msg.pose.orientation = Quaternion(*quaternion_from_euler(0, 0, yaw))
+            x, y, z, w = quaternion_from_euler(0, 0, yaw)
+            pose_msg.pose.orientation = Quaternion(x=x, y=y, z=z, w=w)
+            #pose_msg.pose.orientation = Quaternion(*quaternion_from_euler(0, 0, yaw))
         elif self.mode == "freekick_second":
             vector_ball_to_goal = np.array(goal_position) - np.array(ball_position)
             # pos between ball and goal but 1.5m away from ball and 1m to the side which is closer to us
@@ -78,7 +80,9 @@ class GoToDefensePosition(AbstractActionElement):
             else:
                 pose_msg.pose.position.x = pos_2[0]
                 pose_msg.pose.position.y = pos_2[1]
-            pose_msg.pose.orientation = Quaternion(*quaternion_from_euler(0, 0, yaw))
+            x, y, z, w = quaternion_from_euler(0, 0, yaw)
+            pose_msg.pose.orientation = Quaternion(x=x, y=y, z=z, w=w)
+            #pose_msg.pose.orientation = Quaternion(*quaternion_from_euler(0, 0, yaw))
         else:
             # center point between ball and own goal
             pose_msg.pose.position.x = (goal_position[0] + ball_position[0]) / 2


### PR DESCRIPTION
## Proposed changes
<!--- Describe your changes and why they are necessary. -->
The dictionary was not build that way. Instead of having 'defense' as a key, it has 'defense_0' and so on. 
I tested it in the simulation with the fix and the error did not occur again.

And also the way the Quaternion was initialized before did not seem to work.
## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Put the PR on our Project board

