### PR TITLE
refactor to math.hypot

### DIFF
--- a/bitbots_blackboard/bitbots_blackboard/capsules/head_capsule.py
+++ b/bitbots_blackboard/bitbots_blackboard/capsules/head_capsule.py
@@ -128,7 +128,7 @@ class HeadCapsule:
             return False
 
         # Calculate distante in the joint space
-        distance = math.sqrt((goal_pan - current_pan)**2 + (goal_tilt - current_tilt)**2)
+        distance = math.hypot(goal_pan - current_pan, goal_tilt - current_tilt)
 
         # Caculate step size
         step_count = int(distance / math.radians(3))

--- a/bitbots_blackboard/bitbots_blackboard/capsules/team_data_capsule.py
+++ b/bitbots_blackboard/bitbots_blackboard/capsules/team_data_capsule.py
@@ -84,7 +84,7 @@ class TeamDataCapsule:
         """
         goalie_ball_position = self.get_goalie_ball_position()
         if goalie_ball_position is not None:
-            return math.sqrt(goalie_ball_position[0]**2 + goalie_ball_position[1]**2)
+            return math.hypot(goalie_ball_position[0],goalie_ball_position[1])
         else:
             return None
 
@@ -137,7 +137,7 @@ class TeamDataCapsule:
     def get_robot_ball_euclidean_distance(self, robot_teamdata: TeamData):
         ball_rel_x = robot_teamdata.ball_absolute.pose.position.x - robot_teamdata.robot_position.pose.position.x
         ball_rel_y = robot_teamdata.ball_absolute.pose.position.y - robot_teamdata.robot_position.pose.position.y
-        dist = math.sqrt(ball_rel_x**2 + ball_rel_y**2)
+        dist = math.hypot(ball_rel_x, ball_rel_y)
         return dist
 
     def set_role(self, role: int):

--- a/bitbots_blackboard/bitbots_blackboard/capsules/world_model_capsule.py
+++ b/bitbots_blackboard/bitbots_blackboard/capsules/world_model_capsule.py
@@ -191,7 +191,7 @@ class WorldModelCapsule:
             return np.inf  # worst case (very far away)
         else:
             u, v = ball_pos
-        return math.sqrt(u ** 2 + v ** 2)
+        return math.hypot(u, v)
 
     def get_ball_angle(self) -> float:
         ball_pos = self.get_ball_position_uv()
@@ -433,13 +433,13 @@ class WorldModelCapsule:
         """ Returns the absolute position from the given relative position to the robot"""
         pos_x, pos_y, theta = self.get_current_position()
         angle = math.atan2(v, u) + theta
-        hypotenuse = math.sqrt(u ** 2 + v ** 2)
+        hypotenuse = math.hypot(u, v)
         return pos_x + math.sin(angle) * hypotenuse, pos_y + math.cos(angle) * hypotenuse
 
     def get_distance_to_xy(self, x, y):
         """ Returns distance from robot to given position """
         u, v = self.get_uv_from_xy(x, y)
-        dist = math.sqrt(u ** 2 + v ** 2)
+        dist = math.hypot(u, v)
         return dist
 
     ############

--- a/bitbots_body_behavior/scripts/backup_behavior.py
+++ b/bitbots_body_behavior/scripts/backup_behavior.py
@@ -150,7 +150,7 @@ class Behavior(object):
             x, y = self.get_ball_position_uv(ball_obj)
             self.ball_position = (float(x), float(y))
             # Set ball distance
-            self.ball_distance = math.sqrt(float(self.ball_position[0])**2 + float(self.ball_position[1])**2)
+            self.ball_distance = math.hypot(float(self.ball_position[0]), float(self.ball_position[1]))
             # Calculate the angle in which we are facing the ball
             self.ball_angle = math.atan2(float(self.ball_position[1]),float(self.ball_position[0]))
             # Set the refresh time

--- a/bitbots_head_behavior/bitbots_head_behavior/actions/search_pattern.py
+++ b/bitbots_head_behavior/bitbots_head_behavior/actions/search_pattern.py
@@ -67,7 +67,7 @@ class AbstractSearchPattern(AbstractActionElement):
             point_pan = math.radians(point[0])
             point_tilt = math.radians(point[1])
             # Calc the distance
-            distance = math.sqrt((pan - math.radians(point_pan)) ** 2 + (tilt - math.radians(point_tilt)) ** 2)
+            distance = math.hypot((pan - math.radians(point_pan)), (tilt - math.radians(point_tilt)))
             # Check if distance is smaller than the previous distance
             if distance < min_distance_point[0]:
                 # Reset the distance
@@ -108,7 +108,7 @@ class AbstractSearchPattern(AbstractActionElement):
             # Try the next pattern position
             self.index += 1
         else:
-            distance = math.sqrt((current_head_pan - head_pan) ** 2 + (current_head_tilt - head_tilt) ** 2)
+            distance = math.hypot((current_head_pan - head_pan), (current_head_tilt - head_tilt))
 
             # Increment index when position is reached
             if distance < math.radians(self.threshold):

--- a/bitbots_head_behavior/bitbots_head_behavior/actions/search_recent_ball.py
+++ b/bitbots_head_behavior/bitbots_head_behavior/actions/search_recent_ball.py
@@ -105,9 +105,9 @@ class SearchRecentBall(AbstractLookAt):
             self.index += 1
         else:
             # Distance between the current and the goal position
-            distance = math.sqrt(
-                (current_head_pan - head_motor_goal_pan) ** 2 +
-                (current_head_tilt - head_motor_goal_tilt) ** 2)
+            distance = math.hypot(
+                (current_head_pan - head_motor_goal_pan),
+                (current_head_tilt - head_motor_goal_tilt))
 
             # Increment index when position is reached
             if distance < math.radians(self._threshold):

--- a/bitbots_head_behavior/bitbots_head_behavior/actions/visual_compass_record.py
+++ b/bitbots_head_behavior/bitbots_head_behavior/actions/visual_compass_record.py
@@ -59,7 +59,7 @@ class VisualCompassRecord(AbstractActionElement):
         self.blackboard.head_capsule.send_motor_goals(head_pan, head_tilt, pan_speed=self.pan_speed, tilt_speed=self.tilt_speed)
 
         current_head_pan, current_head_tilt = self.blackboard.head_capsule.get_head_position()
-        distance = math.sqrt((current_head_pan - head_pan) ** 2 + (current_head_tilt - head_tilt) ** 2)
+        distance = math.hypot((current_head_pan - head_pan), (current_head_tilt - head_tilt))
 
         # Increment index when position is reached
         if distance < math.radians(self.threshold):


### PR DESCRIPTION
## Proposed changes
<!--- Describe your changes and why they are necessary. -->
Instead of using `math.sqrt( x**2 + y**2)`, math.hypot(x,y) is now used
## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Put the PR on our Project board

