### PR TITLE
Refactor: Remove unused goal width parameter from config

### DIFF
--- a/bitbots_body_behavior/config/body_behavior.yaml
+++ b/bitbots_body_behavior/config/body_behavior.yaml
@@ -248,6 +248,3 @@
 
       # seconds after which the time to ball is forgotten if a new path to the ball can not be calculated and evaluated
       time_to_ball_remember_time: 1.0
-
-
-    goal_width: 2.6


### PR DESCRIPTION
## Proposed changes

- Removes unused `goal_width` parameter from config
    - This parameter is unused, since we query it from the parameter blackboard (this commit: 73d5114)