### PR TITLE
Fix get_walkready action

### DIFF
--- a/bitbots_blackboard/bitbots_blackboard/capsules/animation_capsule.py
+++ b/bitbots_blackboard/bitbots_blackboard/capsules/animation_capsule.py
@@ -26,7 +26,7 @@ class AnimationCapsule:
 
         :param animation: Name of the animation which shall be played
         :param from_hcm: Marks the action call as a call from the hcm
-        :returns: True if the animation was succesfully depatched
+        :returns: True if the animation was successfully dispatched
         """
         if self.active:
             return False


### PR DESCRIPTION
## Proposed changes
This PR fixes the `get_walkready` action in the body_behavoir.
This didn't always work correctly since the ROS2 migration.

## Related issues


## Necessary checks
- [ ] Update package version
- [X] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [X] Test on your machine
- [ ] Test on the robot
- [X] Put the PR on our Project board

