### PR TITLE
Fix #297: Team ball handling in world_model_capusule

### DIFF
--- a/bitbots_blackboard/bitbots_blackboard/capsules/team_data_capsule.py
+++ b/bitbots_blackboard/bitbots_blackboard/capsules/team_data_capsule.py
@@ -208,7 +208,7 @@ class TeamDataCapsule:
         """Returns the time at which a teammate has seen the ball accurately enough"""
         teammate_ball = self.get_teammate_ball()
         if teammate_ball is not None:
-            return teammate_ball.header.stamp
+            return Time.from_msg(teammate_ball.header.stamp)
         else:
             return Time(seconds=0, nanoseconds=0, clock_type=ClockType.ROS_TIME)
 

--- a/bitbots_blackboard/bitbots_blackboard/capsules/world_model_capsule.py
+++ b/bitbots_blackboard/bitbots_blackboard/capsules/world_model_capsule.py
@@ -207,7 +207,7 @@ class WorldModelCapsule:
             # Set timestamps to zero to get the newest transform when this is transformed later
             self.ball_odom.header.stamp = Time(seconds=0, nanoseconds=0, clock_type=ClockType.ROS_TIME).to_msg()
             self.ball_map.header.stamp = Time(seconds=0, nanoseconds=0, clock_type=ClockType.ROS_TIME).to_msg()
-            self.ball_seen_time = self._blackboard.node.get_clock().now()
+            self.ball_seen_time = Time.from_msg(msg.header.stamp)
             self.ball_publisher.publish(self.ball)
             self.ball_seen = True
 


### PR DESCRIPTION
This PR is part of a larger refactoring regarding the ball handling in the behavior. As this proposed change is urgent, we want to merge this first. I will propose the refactoring PR later.

## Proposed changes
- Fixes error in the `world_module_capsule`, where the two different `Time` implementation could not be compared.

## Related issues
Fixes #297

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Put the PR on our Project board

