### PR TITLE
Only play init animation when in simulation

### DIFF
--- a/bitbots_blackboard/bitbots_blackboard/blackboard.py
+++ b/bitbots_blackboard/bitbots_blackboard/blackboard.py
@@ -24,6 +24,7 @@ class BodyBlackboard:
         self.config = get_parameter_dict(node, "body")
         self.base_footprint_frame: str = self.node.get_parameter("base_footprint_frame").value
         self.map_frame: str = self.node.get_parameter("map_frame").value
+        self.in_sim: bool = self.node.get_parameter("use_sim_time").value
         self.blackboard = BlackboardCapsule(node)
         self.gamestate = GameStatusCapsule(node)
         self.animation = AnimationCapsule(node)

--- a/bitbots_body_behavior/bitbots_body_behavior/actions/play_animation.py
+++ b/bitbots_body_behavior/bitbots_body_behavior/actions/play_animation.py
@@ -75,3 +75,11 @@ class PlayAnimationCheering(AbstractPlayAnimation):
 class PlayAnimationInit(AbstractPlayAnimation):
     def get_animation_name(self):
         return self.blackboard.init_animation
+
+
+class PlayAnimationInitInSim(PlayAnimationInit):
+    def perform(self, reevaluate=False):
+        if self.blackboard.in_sim:
+            return super().perform(reevaluate)
+        else:
+            return self.pop()

--- a/bitbots_body_behavior/bitbots_body_behavior/main.dsd
+++ b/bitbots_body_behavior/bitbots_body_behavior/main.dsd
@@ -8,7 +8,7 @@
 @ChangeAction + action:waiting, @LookAtFieldFeatures, @Stand
 
 #GetWalkreadyAndLocalize
-@ChangeAction + action:waiting + r:false, @PlayAnimationInit + r:false, @LookAtFieldFeatures + r:false, @GetWalkready + r:false, @WalkInPlace
+@ChangeAction + action:waiting + r:false, @PlayAnimationInitInSim + r:false, @LookAtFieldFeatures + r:false, @GetWalkready + r:false, @WalkInPlace
 
 #PerformKick
 @ChangeAction + action:kicking, @LookAtFront, @Stand + duration:1.0, @LookForward + r:false, @KickBallDynamic, @LookAtFieldFeatures + r:false, @WalkInPlace + duration:1 + r:false
@@ -193,10 +193,10 @@ $IsPenalized
                 DONE --> #PositioningReady
         SET --> $SecondaryStateDecider
             PENALTYSHOOT --> $SecondaryStateTeamDecider
-                OUR --> @Stand + duration:0.1 + r:false, @DeactivateHCM + r:false, @LookForward + r:false, @PlayAnimationInit + r:false, @GetWalkready + r:false, @Stand // we need to also see the goalie
+                OUR --> @Stand + duration:0.1 + r:false, @DeactivateHCM + r:false, @LookForward + r:false, @PlayAnimationInitInSim + r:false, @GetWalkready + r:false, @Stand // we need to also see the goalie
                 OTHER --> $BallSeen 
-                    YES --> @Stand + duration:0.1 + r:false, @DeactivateHCM + r:false, @LookForward + r:false, @PlayAnimationInit + r:false, @GetWalkready + r:false, @LookAtBall + r:false, @PlayAnimationGoalieArms + r:false, @Stand // goalie only needs to care about the ball
-                    NO --> @Stand + duration:0.1 + r:false, @DeactivateHCM + r:false, @LookForward + r:false, @PlayAnimationInit + r:false, @GetWalkready + r:false, @SearchBall + r:false, @PlayAnimationGoalieArms + r:false, @Stand
+                    YES --> @Stand + duration:0.1 + r:false, @DeactivateHCM + r:false, @LookForward + r:false, @PlayAnimationInitInSim + r:false, @GetWalkready + r:false, @LookAtBall + r:false, @PlayAnimationGoalieArms + r:false, @Stand // goalie only needs to care about the ball
+                    NO --> @Stand + duration:0.1 + r:false, @DeactivateHCM + r:false, @LookForward + r:false, @PlayAnimationInitInSim + r:false, @GetWalkready + r:false, @SearchBall + r:false, @PlayAnimationGoalieArms + r:false, @Stand
             ELSE --> #StandAndLook
         FINISHED --> #Init
         PLAYING --> $SecondaryStateDecider


### PR DESCRIPTION
The init animation should only be played in simulation when the robot is reset. In real life, it must not be used because it makes the robot fall.